### PR TITLE
fix : review entity에서 softdelete 제외 문법 수정 

### DIFF
--- a/src/main/java/com/sprint/deokhugam/domain/review/entity/Review.java
+++ b/src/main/java/com/sprint/deokhugam/domain/review/entity/Review.java
@@ -19,8 +19,6 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("is_deleted = false")
-@Setter
-@ToString
 public class Review extends BaseUpdatableEntity {
 
     @Column(name = "rating", nullable = false)

--- a/src/main/java/com/sprint/deokhugam/domain/review/entity/Review.java
+++ b/src/main/java/com/sprint/deokhugam/domain/review/entity/Review.java
@@ -18,7 +18,9 @@ import org.hibernate.annotations.SQLRestriction;
 @Table(name = "reviews")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLRestriction("is_deleted <> false")
+@SQLRestriction("is_deleted = false")
+@Setter
+@ToString
 public class Review extends BaseUpdatableEntity {
 
     @Column(name = "rating", nullable = false)


### PR DESCRIPTION
## 📌 PR 요약
`@SQLRestriction("is_deleted <> false")` 가 제대로 작동하지 않아 아래와 같이 변경
`@SQLRestriction("is_deleted = false")`
## ✅ 작업 상세 내용
- review 데이터 중 `is_deleted`값이 `false`인 값만 가져옴

## 🧪 테스트 방법
- 기능 테스트 방식 또는 실행 방법을 설명해주세요.

## 📎 관련 이슈


## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 삭제되지 않은 리뷰만 조회되도록 내부 필터링 조건이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->