### PR TITLE
Feature/comment 상세정보 조회

### DIFF
--- a/src/main/java/com/sprint/deokhugam/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/controller/CommentController.java
@@ -4,10 +4,13 @@ import com.sprint.deokhugam.domain.comment.dto.data.CommentDto;
 import com.sprint.deokhugam.domain.comment.dto.request.CommentCreateRequest;
 import com.sprint.deokhugam.domain.comment.service.CommentService;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +35,16 @@ public class CommentController {
             .status(HttpStatus.CREATED)
             .body(commentDto);
 
+    }
+
+    @GetMapping("/{commentId}")
+    ResponseEntity<CommentDto> getComment(@PathVariable UUID commentId) {
+        log.info("[CommentController] 댓글 상세 조회 요청 - commentId: {}", commentId);
+        CommentDto commentDto = commentService.findById(commentId);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(commentDto);
     }
 
 

--- a/src/main/java/com/sprint/deokhugam/domain/comment/exception/CommentNotFoundException.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,12 @@
+package com.sprint.deokhugam.domain.comment.exception;
+
+import com.sprint.deokhugam.global.exception.NotFoundException;
+import java.util.Map;
+import java.util.UUID;
+
+public class CommentNotFoundException extends NotFoundException {
+
+    public CommentNotFoundException(UUID commentId) {
+        super("Comment", Map.of("id", commentId));
+    }
+}

--- a/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentService.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentService.java
@@ -2,8 +2,11 @@ package com.sprint.deokhugam.domain.comment.service;
 
 import com.sprint.deokhugam.domain.comment.dto.data.CommentDto;
 import com.sprint.deokhugam.domain.comment.dto.request.CommentCreateRequest;
+import java.util.UUID;
 
 public interface CommentService {
 
     CommentDto create(CommentCreateRequest request);
+
+    CommentDto findById(UUID commentId);
 }

--- a/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImpl.java
@@ -3,6 +3,7 @@ package com.sprint.deokhugam.domain.comment.service;
 import com.sprint.deokhugam.domain.comment.dto.data.CommentDto;
 import com.sprint.deokhugam.domain.comment.dto.request.CommentCreateRequest;
 import com.sprint.deokhugam.domain.comment.entity.Comment;
+import com.sprint.deokhugam.domain.comment.exception.CommentNotFoundException;
 import com.sprint.deokhugam.domain.comment.mapper.CommentMapper;
 import com.sprint.deokhugam.domain.comment.repository.CommentRepository;
 import com.sprint.deokhugam.domain.review.entity.Review;
@@ -50,5 +51,17 @@ public class CommentServiceImpl implements CommentService {
 
         return commentMapper.toDto(savedComment);
 
+    }
+
+    @Override
+    public CommentDto findById(UUID commentId) {
+        log.info("[comment] 댓글 상세 조회 요청 - commentId: {}", commentId);
+
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> {
+            log.warn("[comment] 댓글 상세 조회 요청 실패(존재하지않음) - commentId: {}", commentId);
+            return new CommentNotFoundException(commentId);
+        });
+
+        return commentMapper.toDto(comment);
     }
 }

--- a/src/main/java/com/sprint/deokhugam/global/exception/ErrorCode.java
+++ b/src/main/java/com/sprint/deokhugam/global/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     FORBIDDEN_ACTION("이 작업을 수행할 권한이 없습니다", HttpStatus.FORBIDDEN),
     UNAUTHORIZED("인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
     INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    MISSING_REQUEST_HEADER("필수 헤더값을 누락했습니다.", HttpStatus.BAD_REQUEST);
+    MISSING_REQUEST_HEADER("필수 헤더값을 누락했습니다.", HttpStatus.BAD_REQUEST),
+    NO_RESOURCE_FOUND("요청하신 경로를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/test/java/com/sprint/deokhugam/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/comment/controller/CommentControllerTest.java
@@ -2,6 +2,7 @@ package com.sprint.deokhugam.domain.comment.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -139,5 +140,52 @@ class CommentControllerTest {
         result.andExpect(status().is4xxClientError());
     }
 
+    @Test
+    void 댓글_세부정보_요청시_200성공_반환() throws Exception {
+        //given
+        UUID commentId = UUID.randomUUID();
+        CommentDto expectedDto = CommentDto.builder()
+            .id(commentId)
+            .content("test")
+            .reviewId(UUID.randomUUID())
+            .userId(UUID.randomUUID())
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
+            .build();
+        given(commentService.findById(any())).willReturn(expectedDto);
 
+        //when
+        ResultActions result = mockMvc.perform(
+            get("/api/comments/" + commentId)
+        );
+
+        //then
+        result.andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(commentId.toString()))
+            .andExpect(jsonPath("$.content").value("test"));
+    }
+
+    @Test
+    void commentId없이_댓글_세부정보_요청시_404_에러_반환() throws Exception {
+        //given
+        UUID commentId = UUID.randomUUID();
+        CommentDto expectedDto = CommentDto.builder()
+            .id(commentId)
+            .content("test")
+            .reviewId(UUID.randomUUID())
+            .userId(UUID.randomUUID())
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
+            .build();
+        given(commentService.findById(any())).willReturn(expectedDto);
+
+        //when
+        ResultActions result = mockMvc.perform(
+            get("/api/comments/")
+        );
+
+        //then
+        result.andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NO_RESOURCE_FOUND"));
+    }
 }

--- a/src/test/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImplTest.java
@@ -5,12 +5,14 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 
 import com.sprint.deokhugam.domain.book.entity.Book;
 import com.sprint.deokhugam.domain.book.repository.BookRepository;
 import com.sprint.deokhugam.domain.comment.dto.data.CommentDto;
 import com.sprint.deokhugam.domain.comment.dto.request.CommentCreateRequest;
 import com.sprint.deokhugam.domain.comment.entity.Comment;
+import com.sprint.deokhugam.domain.comment.exception.CommentNotFoundException;
 import com.sprint.deokhugam.domain.comment.mapper.CommentMapper;
 import com.sprint.deokhugam.domain.comment.repository.CommentRepository;
 import com.sprint.deokhugam.domain.review.entity.Review;
@@ -168,6 +170,46 @@ public class CommentServiceImplTest {
 
         //then
         assertThat(thrown).isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    void 댓글_세부정보_요청시_댓글정보_반환() throws Exception {
+        //given
+        UUID commentId = UUID.randomUUID();
+        Comment comment = new Comment(mock(Review.class), mock(User.class), "test");
+        CommentDto expectedDto = CommentDto.builder()
+            .id(commentId)
+            .content("test")
+            .reviewId(UUID.randomUUID())
+            .userId(UUID.randomUUID())
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
+            .build();
+        given(commentRepository.findById(any())).willReturn(Optional.of(comment));
+        given(commentMapper.toDto(comment)).willReturn(expectedDto);
+
+        //when
+        CommentDto result = commentService.findById(commentId);
+
+        //then
+        assertThat(result.content()).isEqualTo(expectedDto.content());
+        then(commentRepository).should().findById(commentId);
+        then(commentMapper).should().toDto(comment);
+    }
+
+    @Test
+    void 존재하지않은_댓글_세부정보_요청시_CommentNotFoundException에러_반환() throws Exception {
+        //given
+        UUID commentId = UUID.randomUUID();
+        given(commentRepository.findById(any())).willReturn(Optional.empty());
+
+        //when
+        Throwable thrown = catchThrowable(() -> commentService.findById(commentId));
+
+        //then
+        assertThat(thrown).isInstanceOf(CommentNotFoundException.class);
+        then(commentRepository).should().findById(commentId);
+        
     }
 
 }

--- a/src/test/java/com/sprint/deokhugam/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/review/controller/ReviewControllerTest.java
@@ -242,7 +242,8 @@ class ReviewControllerTest {
         );
 
         //then
-        result.andExpect(status().is5xxServerError());
+        result.andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NO_RESOURCE_FOUND"));
     }
 
     @Test


### PR DESCRIPTION
## 📌 PR 요약
- comment 상세정보조회 API 입니다. 
- exceptionhandler에 `MissingRequestHeaderException`, `NoResourceFoundException` 추가
- @hyohyo-zz 님이 언급하신 review test 2개 실패한것도 수정했습니다

```cURL

curl --location --request GET 'http://localhost:8081/api/comments/f2de9db3-69cb-4c67-91f3-90bc77b766ed' \
--header 'Content-Type: application/json' \
--data '{
    "reviewId": "044458f4-72a3-49aa-96f8-1a5160f444e2",
    "userId": "36404724-4603-4cf4-8a8c-ebff46deb51b",
    "content": "새로운댓글"
}'

```
<img width="991" height="605" alt="스크린샷 2025-07-16 11 10 35" src="https://github.com/user-attachments/assets/1684d2d7-134c-431c-bc8e-24e86426da8f" />


## ✅ 작업 상세 내용
- [x] 주요 기능 구현
- [x] 관련 에러타입 추가
- [x] 기타 테스트

## 🧪 테스트 방법
- 기능 테스트 방식 또는 실행 방법을 설명해주세요.
<img width="928" height="736" alt="스크린샷 2025-07-16 11 10 19" src="https://github.com/user-attachments/assets/ac533208-6734-4fad-a11a-0532f99323b9" />

## 📎 관련 이슈


## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 댓글 ID로 댓글 상세 정보를 조회할 수 있는 GET 엔드포인트가 추가되었습니다.
  * 존재하지 않는 댓글 조회 시, 상세한 오류 메시지를 제공하는 예외가 도입되었습니다.

* **버그 수정**
  * 잘못된 경로 또는 요청 헤더 누락 시, 명확한 오류 코드와 메시지로 응답하도록 예외 처리가 개선되었습니다.

* **테스트**
  * 댓글 상세 조회 및 오류 상황에 대한 단위 테스트와 컨트롤러 테스트가 추가되었습니다.
  * 리뷰 삭제 시 ID 누락에 대한 오류 응답 검증이 404 상태 및 명확한 코드로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->