### PR TITLE
Fix/리뷰 목록 전체 조회할때 안보이는 문제 수정

### DIFF
--- a/src/main/java/com/sprint/deokhugam/domain/review/dto/request/ReviewGetRequest.java
+++ b/src/main/java/com/sprint/deokhugam/domain/review/dto/request/ReviewGetRequest.java
@@ -1,25 +1,35 @@
 package com.sprint.deokhugam.domain.review.dto.request;
 
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.Instant;
 import java.util.UUID;
-import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-@Builder(toBuilder = true)
-public class ReviewGetRequest {
-
-    private UUID userId; // 작성자 ID
-    private UUID bookId; // 도서 ID
-    private String keyword; // 검색 키워드 (작성자 닉네임 | 내용)
-    private String orderBy; // 정렬 기준(createdAt | rating)
-    private String direction; // 정렬 방향( DESC | ASC )
-    private Object cursor; //  페이지네이션 커서
-    private Instant after; // 보조 커서(createdAt)
+public record ReviewGetRequest(
+    UUID userId, // 작성자 ID
+    UUID bookId, // 도서 ID
+    String keyword, // 검색 키워드 (작성자 닉네임 | 내용)
+    Object cursor, //  페이지네이션 커서
+    Instant after, // 보조 커서(createdAt)
     @Positive
-    private Integer limit = 50; // 페이지 크기 , default:50
-    @NotNull
-    private UUID requestUserId; // 요청자 ID , not null
+    Integer limit, // 페이지 크기 , default:50
+    String orderBy, // 정렬 기준(createdAt | rating)
+    String direction  // 정렬 방향( DESC | ASC )
+) {
+
+    public ReviewGetRequest {
+        if (limit == null) {
+            limit = 50;
+        }
+        if (orderBy == null) {
+            orderBy = "createdAt";
+        }
+        if (direction == null) {
+            direction = "ASC";
+        }
+    }
+
+    public ReviewGetRequest withLimit(Integer newLimit) {
+        return new ReviewGetRequest(this.userId, this.bookId, this.keyword, this.cursor, this.after,
+            newLimit, this.orderBy, this.direction);
+    }
 }

--- a/src/main/java/com/sprint/deokhugam/domain/review/repository/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/sprint/deokhugam/domain/review/repository/CustomReviewRepositoryImpl.java
@@ -60,22 +60,11 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
         String orderBy = params.orderBy();
 
         BooleanBuilder whereCondition = new BooleanBuilder();
-        BooleanBuilder cursorCondition = new BooleanBuilder();
-
-        whereCondition.and(filterByIdAndKeyword(review, params));
-
-        //Q. after만 오는 경우는 의미없음
-        boolean isCursorExisted = params.cursor() != null;
-        if (isCursorExisted) {
-            cursorCondition =
-                orderBy.equals(ORDER_BY_CREATED_AT) ? filterByCreatedAt(review, params)
-                    : filterByRating(review, params);
-        }
 
         return queryFactory
             .select(review.count())
             .from(review)
-            .where(whereCondition, cursorCondition)
+            .where(whereCondition)
             .fetchOne();
 
     }

--- a/src/main/java/com/sprint/deokhugam/domain/review/repository/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/sprint/deokhugam/domain/review/repository/CustomReviewRepositoryImpl.java
@@ -29,18 +29,18 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
 
     public List<Review> findAll(ReviewGetRequest params) {
         QReview review = QReview.review;
-        String direction = params.getDirection();
-        String orderBy = params.getOrderBy();
+        String direction = params.direction();
+        String orderBy = params.orderBy();
 
         BooleanBuilder whereCondition = new BooleanBuilder();
         BooleanBuilder cursorCondition = new BooleanBuilder();
 
-        if (params.getUserId() != null || params.getBookId() != null
-            || params.getKeyword() != null) {
+        if (params.userId() != null || params.bookId() != null
+            || params.keyword() != null) {
             whereCondition.and(filterByIdAndKeyword(review, params));
         }
         //Q. after만 오는 경우는 의미없음
-        boolean isCursorExisted = params.getCursor() != null;
+        boolean isCursorExisted = params.cursor() != null;
         if (isCursorExisted) {
             cursorCondition =
                 orderBy.equals(ORDER_BY_CREATED_AT) ? filterByCreatedAt(review, params)
@@ -51,13 +51,13 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
             .selectFrom(review)
             .where(whereCondition, cursorCondition)
             .orderBy(getOrderSpecifiers(review, orderBy, direction))
-            .limit(params.getLimit())
+            .limit(params.limit())
             .fetch();
     }
 
     public Long countAllByFilterCondition(ReviewGetRequest params) {
         QReview review = QReview.review;
-        String orderBy = params.getOrderBy();
+        String orderBy = params.orderBy();
 
         BooleanBuilder whereCondition = new BooleanBuilder();
         BooleanBuilder cursorCondition = new BooleanBuilder();
@@ -65,7 +65,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
         whereCondition.and(filterByIdAndKeyword(review, params));
 
         //Q. after만 오는 경우는 의미없음
-        boolean isCursorExisted = params.getCursor() != null;
+        boolean isCursorExisted = params.cursor() != null;
         if (isCursorExisted) {
             cursorCondition =
                 orderBy.equals(ORDER_BY_CREATED_AT) ? filterByCreatedAt(review, params)
@@ -82,9 +82,9 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
 
     private BooleanBuilder filterByIdAndKeyword(QReview review, ReviewGetRequest params) {
         BooleanBuilder whereCondition = new BooleanBuilder();
-        String keyword = params.getKeyword();
-        UUID userId = params.getUserId();
-        UUID bookId = params.getBookId();
+        String keyword = params.keyword();
+        UUID userId = params.userId();
+        UUID bookId = params.bookId();
 
         if (userId != null) {
             whereCondition.and(review.user.id.eq(userId));
@@ -108,8 +108,8 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
     private BooleanBuilder filterByCreatedAt(QReview review, ReviewGetRequest params) {
         try {
             BooleanBuilder whereCondition = new BooleanBuilder();
-            String direction = params.getDirection();
-            Instant cursor = Instant.parse(params.getCursor().toString());
+            String direction = params.direction();
+            Instant cursor = Instant.parse(params.cursor().toString());
             if (direction.equals(ORDER_DIRECTION_DESC)) {
                 whereCondition
                     .or(review.createdAt.lt(cursor));
@@ -120,7 +120,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
             return whereCondition;
         } catch (DateTimeParseException e) {
             throw new InvalidTypeException("review",
-                Map.of("requestedCursor", params.getCursor().toString()));
+                Map.of("requestedCursor", params.cursor().toString()));
         }
 
     }
@@ -128,9 +128,9 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
     private BooleanBuilder filterByRating(QReview review, ReviewGetRequest params) {
         try {
             BooleanBuilder whereCondition = new BooleanBuilder();
-            String direction = params.getDirection();
-            Integer cursor = Integer.valueOf(params.getCursor().toString());
-            Instant after = params.getAfter();
+            String direction = params.direction();
+            Integer cursor = Integer.valueOf(params.cursor().toString());
+            Instant after = params.after();
 
             if (direction.equals(ORDER_DIRECTION_DESC)) {
                 whereCondition
@@ -144,7 +144,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
             return whereCondition;
         } catch (NumberFormatException e) {
             throw new InvalidTypeException("review",
-                Map.of("requestedCursor", params.getCursor().toString()));
+                Map.of("requestedCursor", params.cursor().toString()));
         }
 
     }

--- a/src/test/java/com/sprint/deokhugam/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/review/controller/ReviewControllerTest.java
@@ -168,23 +168,6 @@ class ReviewControllerTest {
     }
 
     @Test
-    void requestId가_없이_전체조회하면_400_에러를__반환한다() throws Exception {
-        //given
-        given(reviewService.findAll(any(ReviewGetRequest.class), any(UUID.class))).willReturn(
-            mockResponse);
-
-        //when
-        ResultActions result = mockMvc.perform(
-            get("/api/reviews")
-                .header("Deokhugam-Request-User-ID", "cea1a965-2817-4431-90e3-e5701c70d43d")
-        );
-
-        //then
-        result.andExpect(status().isBadRequest());
-    }
-
-
-    @Test
     void 리뷰_정보_조회에_성공하면_200응답을_반환한다() throws Exception {
         // given
         UUID reviewId = UUID.randomUUID();

--- a/src/test/java/com/sprint/deokhugam/domain/review/repository/CustomReviewRepositoryTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/review/repository/CustomReviewRepositoryTest.java
@@ -160,12 +160,8 @@ public class CustomReviewRepositoryTest {
     @Test
     void 키워드를_포함하여_리뷰를_전체조회한다() throws Exception {
         //given
-        ReviewGetRequest request = ReviewGetRequest.builder()
-            .orderBy("createdAt")
-            .direction("DESC")
-            .keyword("유저2") // 닉네임
-            .limit(2)
-            .build();
+        ReviewGetRequest request = new ReviewGetRequest(null, null, "유저2", null, null, 2,
+            "createdAt", "DESC");
 
         //when
         List<Review> result = reviewRepository.findAll(request);
@@ -179,13 +175,8 @@ public class CustomReviewRepositoryTest {
     void userId가_일치하는_리뷰를_전체조회한다() throws Exception {
         // given
         UUID userId = reviewRepository.findAll().get(0).getUser().getId();
-        ReviewGetRequest request = ReviewGetRequest.builder()
-            .orderBy("createdAt")
-            .direction("DESC")
-            .userId(userId)
-            .limit(10)
-            .build();
-
+        ReviewGetRequest request = new ReviewGetRequest(userId, null, null, null, null, 10,
+            "createdAt", "DESC");
         // when
         List<Review> result = reviewRepository.findAll(request);
 
@@ -198,13 +189,8 @@ public class CustomReviewRepositoryTest {
     void bookId가_일치하는_리뷰를_전체조회한다() throws Exception {
         // given
         UUID bookId = reviewRepository.findAll().get(1).getBook().getId();
-        ReviewGetRequest request = ReviewGetRequest.builder()
-            .orderBy("createdAt")
-            .direction("DESC")
-            .bookId(bookId)
-            .limit(10)
-            .build();
-
+        ReviewGetRequest request = new ReviewGetRequest(null, bookId, null, null, null, 10,
+            "createdAt", "DESC");
         // when
         List<Review> result = reviewRepository.findAll(request);
 
@@ -218,14 +204,8 @@ public class CustomReviewRepositoryTest {
     void 최신순_오름차순으로_다음페이지_리뷰를_전체조회한다() throws Exception {
         // given
         Instant after = Instant.parse("2025-01-02T00:00:00Z");
-        ReviewGetRequest request = ReviewGetRequest.builder()
-            .orderBy("createdAt")
-            .direction("ASC")
-            .cursor(after)
-            .after(after)
-            .limit(10)
-            .build();
-
+        ReviewGetRequest request = new ReviewGetRequest(null, null, null, after, after, 10,
+            "createdAt", "DESC");
         // when
         List<Review> result = reviewRepository.findAll(request);
 
@@ -239,13 +219,8 @@ public class CustomReviewRepositoryTest {
     void 최신순으로_조회하지만_cursor값이_datetime타입이_아니라면_400에러를_반환한다() throws Exception {
         // given
         Instant after = Instant.parse("2025-01-02T00:00:00Z");
-        ReviewGetRequest request = ReviewGetRequest.builder()
-            .orderBy("createdAt")
-            .direction("ASC")
-            .cursor("1.0")
-            .after(after)
-            .limit(10)
-            .build();
+        ReviewGetRequest request = new ReviewGetRequest(null, null, null, "1", after, 10,
+            "createdAt", "ASC");
 
         // when
         Throwable thrown = catchThrowable(() -> reviewRepository.findAll(request));
@@ -259,13 +234,8 @@ public class CustomReviewRepositoryTest {
     void 평점순_오름차순으로_다음페이지_리뷰를_전체조회한다() throws Exception {
         // given
         Instant after = Instant.parse("2025-01-02T00:00:00Z");
-        ReviewGetRequest request = ReviewGetRequest.builder()
-            .orderBy("rating")
-            .direction("ASC")
-            .cursor("1")
-            .after(after)
-            .limit(10)
-            .build();
+        ReviewGetRequest request = new ReviewGetRequest(null, null, null, "1", after, 10,
+            "rating", "ASC");
 
         // when
         List<Review> result = reviewRepository.findAll(request);
@@ -283,13 +253,8 @@ public class CustomReviewRepositoryTest {
     void 평점순으로_조회하지만_cursor값이_Integer타입이_아니라면_400에러를_반환한다() throws Exception {
         // given
         Instant after = Instant.parse("2025-01-02T00:00:00Z");
-        ReviewGetRequest request = ReviewGetRequest.builder()
-            .orderBy("rating")
-            .direction("ASC")
-            .cursor("invalid")
-            .after(after)
-            .limit(10)
-            .build();
+        ReviewGetRequest request = new ReviewGetRequest(null, null, null, "invalid", after, 10,
+            "rating", "ASC");
 
         // when
         Throwable thrown = catchThrowable(() -> reviewRepository.findAll(request));
@@ -303,12 +268,8 @@ public class CustomReviewRepositoryTest {
     @Test
     void 총_리뷰갯수_반환() throws Exception {
         // given
-        ReviewGetRequest request = ReviewGetRequest.builder()
-            .orderBy("createdAt")
-            .direction("ASC")
-            .limit(10)
-            .build();
-
+        ReviewGetRequest request = new ReviewGetRequest(null, null, null, null, null, 10,
+            "createdAt", "ASC");
         // when
         Long result = reviewRepository.countAllByFilterCondition(request);
 
@@ -321,13 +282,8 @@ public class CustomReviewRepositoryTest {
     void userId가_일치하는_총_리뷰갯수_반환() throws Exception {
         // given
         UUID userId = reviewRepository.findAll().get(0).getUser().getId();
-        ReviewGetRequest request = ReviewGetRequest.builder()
-            .orderBy("createdAt")
-            .direction("DESC")
-            .userId(userId)
-            .limit(10)
-            .build();
-
+        ReviewGetRequest request = new ReviewGetRequest(userId, null, null, null, null, 10,
+            "createdAt", "DESC");
         // when
         Long result = reviewRepository.countAllByFilterCondition(request);
 

--- a/src/test/java/com/sprint/deokhugam/domain/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/review/service/ReviewServiceImplTest.java
@@ -388,7 +388,8 @@ public class ReviewServiceImplTest {
         given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
 
         // when
-        Throwable thrown = catchThrowable(() -> reviewService.findById(reviewId, UUID.randomUUID()));
+        Throwable thrown = catchThrowable(
+            () -> reviewService.findById(reviewId, UUID.randomUUID()));
 
         // then
         assertThat(thrown)
@@ -399,11 +400,8 @@ public class ReviewServiceImplTest {
     @DisplayName("첫 페이지 조회 - 데이터 있을때")
     void 최신순_오름차순으로_리뷰를_전체조회한다() throws Exception {
         //given
-        ReviewGetRequest request = ReviewGetRequest.builder()
-            .orderBy("createdAt")
-            .direction("ASC")
-            .limit(2)
-            .build();
+        ReviewGetRequest request = new ReviewGetRequest(null, null, null, null, null, 2,
+            "createdAt", "ASC");
         given(reviewRepository.findAll(any(ReviewGetRequest.class)))
             .willReturn(mockReviews.subList(0, 3));
         given(reviewRepository.countAllByFilterCondition(any()))
@@ -429,11 +427,8 @@ public class ReviewServiceImplTest {
     @DisplayName("첫 페이지 조회- 데이터없을때")
     void 데이터가_없을때_최신순_오름차순으로_리뷰를_전체조회한다() throws Exception {
         //given
-        ReviewGetRequest request = ReviewGetRequest.builder()
-            .orderBy("createdAt")
-            .direction("ASC")
-            .limit(2)
-            .build();
+        ReviewGetRequest request = new ReviewGetRequest(null, null, null, null, null, 2,
+            "createdAt", "ASC");
         given(reviewRepository.findAll(any(ReviewGetRequest.class)))
             .willReturn(null);
 
@@ -455,11 +450,8 @@ public class ReviewServiceImplTest {
     @DisplayName("유효하지 않은 정렬 기준 - 예외 발생")
     void 유효하지_않은_정렬_기준_예외_발생() throws Exception {
         //given
-        ReviewGetRequest request = ReviewGetRequest.builder()
-            .orderBy("invalid")
-            .direction("ASC")
-            .limit(2)
-            .build();
+        ReviewGetRequest request = new ReviewGetRequest(null, null, null, null, null, 2,
+            "invalid", "ASC");
         given(reviewRepository.findAll(any(ReviewGetRequest.class)))
             .willReturn(mockReviews.subList(0, 3));
 
@@ -552,7 +544,8 @@ public class ReviewServiceImplTest {
     }
 
     @Test
-    void 하드_삭제하려는_리뷰가_본인이_작성한_리뷰가_아니라면_ReviewUnauthorizedAccessException_에러를_반환한다() throws Exception {
+    void 하드_삭제하려는_리뷰가_본인이_작성한_리뷰가_아니라면_ReviewUnauthorizedAccessException_에러를_반환한다()
+        throws Exception {
         //given
         UUID reviewId = UUID.fromString("cea1a965-2817-4431-90e3-e5701c70d43d");
         UUID userId = UUID.fromString("36404724-4603-4cf4-8a8c-111111111111");


### PR DESCRIPTION
## 📌 PR 요약
- 리뷰 목록 전체 조회시 파라미터로 requestUserId 필수값으로 받았었는데, 이부분 제거했습니다. 
- userId는 header에 있는 deokhugam-request-user-id 값으로 사용합니다. 
- ReviewGetRequest Dto를 class에서 record로 변경했습니다. 타입만 바꾸는건데 생각보다 변경할부분이 많네요 ㅠㅠ
## ✅ 작업 상세 내용
- [x] 관련 API 변경
- [x] 기타 리팩터링

## 🧪 테스트 방법
- 기존에 있던 review 테스트 다 통과했습니다. 
-  

## 📎 관련 이슈
- 프론트에서 리뷰 목록 전체 조회할때 안보이는 문제 수정.

## 추가 전달 사항
- record로 바꾸면서 builder 패턴을 못쓰니까 좀 답답하네요. 좋은 방법있으면 추천부탁드립니당~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 리뷰 조회 요청 방식이 개선되어 일부 필드가 제거되고 기본값 처리 방식이 변경되었습니다.
  * 내부적으로 빌더 패턴 대신 레코드 생성자와 메서드가 도입되어 객체 생성 방식이 간소화되었습니다.
  * 코드 전반에서 getter 호출 방식이 간결하게 변경되고 불필요한 쿼리 조건이 제거되었습니다.
  * 로깅 구문이 가독성 향상을 위해 포맷팅되었습니다.

* **Tests**
  * 불필요한 테스트가 제거되고, 테스트 코드의 객체 생성 방식이 빌더에서 직접 생성자로 단순화되었습니다.
  * 일부 테스트 메서드의 형식과 예외 선언부가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->