### PR TITLE
Common/ aop 의존성 설치 및 레이어별 aop 로그 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 
     // OCR - tesseract
     implementation 'net.sourceforge.tess4j:tess4j:5.11.0'
+
+    // aop
+    implementation "org.springframework.boot:spring-boot-starter-aop"
 }
 
 // querydsl Q클래스 생성 경로설정

--- a/src/main/java/com/sprint/deokhugam/global/aop/LoggingAspect.java
+++ b/src/main/java/com/sprint/deokhugam/global/aop/LoggingAspect.java
@@ -1,0 +1,90 @@
+package com.sprint.deokhugam.global.aop;
+
+import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+
+    /**
+     * 컨트롤러 계층의 하위 패키지 포함 모든 메서드에 대한 포인트 컷
+     */
+    @Pointcut("execution(* com.sprint.deokhugam.domain..controller..*.*(..))")
+    private void controllerLayer() {
+    }
+
+    /**
+     * 서비스 계층의 하위 패키지 포함 모든 메서드에 대한 포인트 컷
+     */
+    @Pointcut("execution(* com.sprint.deokhugam.domain..service..*.*(..))")
+    private void serviceLayer() {
+    }
+
+    /**
+     * 서비스 계층의 하위 패키지 포함 모든 메서드에 대한 포인트 컷
+     */
+    @Pointcut("execution(* com.sprint.deokhugam.domain..repository..*.*(..))")
+    private void repositoryLayer() {
+    }
+
+
+    @Around("controllerLayer()")
+    public Object logController(ProceedingJoinPoint joinPoint) throws Throwable {
+        return logExecution(joinPoint, "Controller");
+    }
+
+    @Around("serviceLayer()")
+    public Object logService(ProceedingJoinPoint joinPoint) throws Throwable {
+        return logExecution(joinPoint, "Service");
+    }
+
+    @Around("repositoryLayer()")
+    public Object logRepository(ProceedingJoinPoint joinPoint) throws Throwable {
+        return logExecution(joinPoint, "Repository");
+    }
+
+
+    /**
+     * 공통 로깅 로직 수행하는 메서드 메서드 실행 전후로 로그 출력
+     *
+     * @param joinPoint 실행 대상 메서드에 대한 정보
+     * @param layer     "Controller", "Service" 구분용 문자열
+     * @return 실행 결과 (원래 메서드의 반환값)
+     * @throws Throwable 메서드 실행 중 발생할 수 있는 예외
+     */
+    private Object logExecution(ProceedingJoinPoint joinPoint, String layer) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String className = signature.getDeclaringType().getSimpleName();
+        String methodName = signature.getName();
+
+        log.info("\n>>>[{}] {}#{} 시작 - args={}", layer, className, methodName,
+            Arrays.toString(joinPoint.getArgs()));
+
+        long startTime = System.currentTimeMillis();
+
+        try {
+            Object result = joinPoint.proceed();
+            long elapsed = System.currentTimeMillis() - startTime;
+
+            log.info("\n>>>[{}] {}#{} 완료 - {}ms - result={}", layer, className, methodName, elapsed,
+                result != null ? result.getClass().getSimpleName() : null);
+
+            return result;
+        } catch (Throwable t) {
+            long elapsed = System.currentTimeMillis() - startTime;
+            log.error("\n>>>[{}] {}#{} 예외 발생 - {}ms - {}: {}", layer, className, methodName,
+                elapsed,
+                t.getClass().getSimpleName(), t.getMessage());
+
+            throw t;
+        }
+    }
+}

--- a/src/main/java/com/sprint/deokhugam/global/aop/LoggingAspect.java
+++ b/src/main/java/com/sprint/deokhugam/global/aop/LoggingAspect.java
@@ -29,7 +29,7 @@ public class LoggingAspect {
     }
 
     /**
-     * 서비스 계층의 하위 패키지 포함 모든 메서드에 대한 포인트 컷
+     * 레포지토리 계층의 하위 패키지 포함 모든 메서드에 대한 포인트 컷
      */
     @Pointcut("execution(* com.sprint.deokhugam.domain..repository..*.*(..))")
     private void repositoryLayer() {


### PR DESCRIPTION
## 📌 PR 요약
 aop 의존성 설치 및 레이어별 aop 로그 추가했습니다
현아님이 참고하라고 주신 템플릿 요긴하게 잘썼습니다~!👍🏼

## ✅ 작업 상세 내용
- [x] 주요 기능 구현


## 🧪 테스트 방법
<img width="1385" height="397" alt="스크린샷 2025-07-17 16 45 35" src="https://github.com/user-attachments/assets/1113a472-432f-4a74-b44a-70bff310faef" />


## 📎 관련 이슈
- Close #123

## 추가 전달 사항
컨트롤러, 서비스, 레포지토리 다 추가했는데 레포지토리는 로그가 너무 많이찍혀서 의미가 있을지 의문입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **New Features**
  * 컨트롤러, 서비스, 레포지토리 계층에 대한 중앙 집중식 로깅 기능이 추가되었습니다. 각 계층의 메소드 실행 시 시작, 종료, 소요 시간, 결과 및 예외 정보를 자동으로 기록합니다.
* **Chores**
  * AOP 지원을 위해 Spring Boot AOP 스타터가 프로젝트에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->