### PR TITLE
Feature/comment delete

### DIFF
--- a/src/main/java/com/sprint/deokhugam/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/controller/CommentController.java
@@ -6,11 +6,14 @@ import com.sprint.deokhugam.domain.comment.dto.request.CommentUpdateRequest;
 import com.sprint.deokhugam.domain.comment.service.CommentService;
 import com.sprint.deokhugam.global.dto.response.CursorPageResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/api/comments")
 public class CommentController {
 
@@ -78,5 +82,29 @@ public class CommentController {
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(response);
+    }
+
+    @DeleteMapping("/{commentId}")
+    ResponseEntity<Void> softDeleteComment(
+        @PathVariable @NotNull UUID commentId,
+        @RequestHeader("Deokhugam-Request-User-ID") @NotNull UUID requestUserId
+    ) {
+        commentService.softDelete(commentId, requestUserId);
+
+        return ResponseEntity
+            .noContent()
+            .build();
+    }
+
+    @DeleteMapping("/{commentId}/hard")
+    ResponseEntity<Void> hardDeleteComment(
+        @PathVariable @NotNull UUID commentId,
+        @RequestHeader("Deokhugam-Request-User-ID") @NotNull UUID requestUserId
+    ) {
+        commentService.hardDelete(commentId, requestUserId);
+
+        return ResponseEntity
+            .noContent()
+            .build();
     }
 }

--- a/src/main/java/com/sprint/deokhugam/domain/comment/entity/Comment.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/entity/Comment.java
@@ -47,9 +47,7 @@ public class Comment extends BaseUpdatableEntity {
     }
 
     public void update(String newContent) {
-        if (newContent != null && !newContent.equals(this.content)) {
-            this.content = newContent;
-        }
+        this.content = newContent;
     }
 
     public void softDelete() {

--- a/src/main/java/com/sprint/deokhugam/domain/comment/exception/CommentNotSoftDeletedException.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/exception/CommentNotSoftDeletedException.java
@@ -1,10 +1,10 @@
 package com.sprint.deokhugam.domain.comment.exception;
 
-import com.sprint.deokhugam.global.exception.NotFoundException;
+import com.sprint.deokhugam.global.exception.BadRequestException;
 import java.util.Map;
 import java.util.UUID;
 
-public class CommentNotSoftDeletedException extends NotFoundException {
+public class CommentNotSoftDeletedException extends BadRequestException {
 
     public CommentNotSoftDeletedException(UUID commentId) {
         super("comment", Map.of("commentId", commentId, "message", "논리 삭제되지 않은 댓글입니다."));

--- a/src/main/java/com/sprint/deokhugam/domain/comment/exception/CommentNotSoftDeletedException.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/exception/CommentNotSoftDeletedException.java
@@ -1,0 +1,12 @@
+package com.sprint.deokhugam.domain.comment.exception;
+
+import com.sprint.deokhugam.global.exception.NotFoundException;
+import java.util.Map;
+import java.util.UUID;
+
+public class CommentNotSoftDeletedException extends NotFoundException {
+
+    public CommentNotSoftDeletedException(UUID commentId) {
+        super("comment", Map.of("commentId", commentId, "message", "논리 삭제되지 않은 댓글입니다."));
+    }
+}

--- a/src/main/java/com/sprint/deokhugam/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/repository/CommentRepository.java
@@ -22,5 +22,5 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
     Long countByReviewId(UUID reviewId);
 
     @Query(value = "SELECT * FROM comments WHERE id = :id", nativeQuery = true)
-    Optional<Comment> findByIdIncludingDeleted(@Param("id") UUID reviewId);
+    Optional<Comment> findByIdIncludingDeleted(@Param("id") UUID commentId);
 }

--- a/src/main/java/com/sprint/deokhugam/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/repository/CommentRepository.java
@@ -2,11 +2,14 @@ package com.sprint.deokhugam.domain.comment.repository;
 
 import com.sprint.deokhugam.domain.comment.entity.Comment;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
@@ -17,4 +20,7 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
     Slice<Comment> findByReviewIdAndCreatedAtLessThan(UUID reviewId, Instant cursor, Pageable pageable);
 
     Long countByReviewId(UUID reviewId);
+
+    @Query(value = "SELECT * FROM comments WHERE id = :id", nativeQuery = true)
+    Optional<Comment> findByIdIncludingDeleted(@Param("id") UUID reviewId);
 }

--- a/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentService.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentService.java
@@ -15,4 +15,8 @@ public interface CommentService {
     CommentDto findById(UUID commentId);
 
     CommentDto updateById(UUID commentId, CommentUpdateRequest request, UUID requestUserId);
+
+    void softDelete(UUID commentId, UUID userId);
+
+    void hardDelete(UUID commentId, UUID userId);
 }

--- a/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImpl.java
@@ -195,9 +195,7 @@ public class CommentServiceImpl implements CommentService {
 
     private void validateAuthorizedUser(Comment comment, UUID userId) {
         if (!comment.getUser().getId().equals(userId)) {
-            log.warn("[comment] {} - 해당 유저는 권한이 없음: commentId={}, userId={}", comment.getId(),
-                userId,
-                userId);
+            log.warn("[comment] 권한 검증 실패 - 해당 유저는 권한이 없음: commentId={}, userId={}", comment.getId(), userId);
             throw new CommentUnauthorizedAccessException(comment.getId(), userId);
         }
     }

--- a/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImpl.java
@@ -5,12 +5,15 @@ import com.sprint.deokhugam.domain.comment.dto.request.CommentCreateRequest;
 import com.sprint.deokhugam.domain.comment.dto.request.CommentUpdateRequest;
 import com.sprint.deokhugam.domain.comment.entity.Comment;
 import com.sprint.deokhugam.domain.comment.exception.CommentNotFoundException;
+import com.sprint.deokhugam.domain.comment.exception.CommentNotSoftDeletedException;
 import com.sprint.deokhugam.domain.comment.exception.CommentUnauthorizedAccessException;
 import com.sprint.deokhugam.domain.comment.exception.InvalidCursorTypeException;
 import com.sprint.deokhugam.domain.comment.mapper.CommentMapper;
 import com.sprint.deokhugam.domain.comment.repository.CommentRepository;
+import com.sprint.deokhugam.domain.review.dto.request.ReviewFeature;
 import com.sprint.deokhugam.domain.review.entity.Review;
 import com.sprint.deokhugam.domain.review.exception.ReviewNotFoundException;
+import com.sprint.deokhugam.domain.review.exception.ReviewNotSoftDeletedException;
 import com.sprint.deokhugam.domain.review.repository.ReviewRepository;
 import com.sprint.deokhugam.domain.user.entity.User;
 import com.sprint.deokhugam.domain.user.exception.UserNotFoundException;
@@ -158,6 +161,36 @@ public class CommentServiceImpl implements CommentService {
         );
 
         return commentResponse;
+    }
+
+    @Transactional
+    @Override
+    public void softDelete(UUID commentId, UUID userId) {
+        Comment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> new CommentNotFoundException(commentId));
+        log.warn("[comment] 논리 삭제 실패 - 존재하지 않는 댓글: {}", commentId);
+
+        validateAuthorizedUser(comment, userId);
+        comment.softDelete();
+        comment.getReview().decreaseCommentCount();
+    }
+
+    @Transactional
+    @Override
+    public void hardDelete(UUID commentId, UUID userId) {
+        Comment comment = commentRepository.findByIdIncludingDeleted(commentId)
+            .orElseThrow(() -> {
+                log.warn("[comment] 물리 삭제 실패 - 존재하지 않는 댓글: {}", commentId);
+                return new CommentNotFoundException(commentId);
+            });
+
+        if (!comment.getIsDeleted()) {
+            log.warn("[comment] 물리 삭제 실패 - 논리 삭제되지 않음: {}", commentId);
+            throw new CommentNotSoftDeletedException(commentId);
+        }
+
+        validateAuthorizedUser(comment, userId);
+        commentRepository.delete(comment);
     }
 
     private void validateAuthorizedUser(Comment comment, UUID userId) {

--- a/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImpl.java
@@ -167,8 +167,11 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public void softDelete(UUID commentId, UUID userId) {
         Comment comment = commentRepository.findById(commentId)
-            .orElseThrow(() -> new CommentNotFoundException(commentId));
-        log.warn("[comment] 논리 삭제 실패 - 존재하지 않는 댓글: {}", commentId);
+            .orElseThrow(() -> {
+                log.warn("[comment] 논리 삭제 실패 - 존재하지 않는 댓글: {}", commentId);
+                return new CommentNotFoundException(commentId);
+            });
+
 
         validateAuthorizedUser(comment, userId);
         comment.softDelete();

--- a/src/main/java/com/sprint/deokhugam/domain/review/entity/Review.java
+++ b/src/main/java/com/sprint/deokhugam/domain/review/entity/Review.java
@@ -59,12 +59,8 @@ public class Review extends BaseUpdatableEntity {
     }
 
     public void update(String newContent, Integer newRating) {
-        if (newContent != null && !newContent.trim().isEmpty()) {
-            this.content = newContent;
-        }
-        if (newRating != null && newRating >= 0.0 && newRating <= 5.0) {
-            this.rating = newRating;
-        }
+        this.content = newContent;
+        this.rating = newRating;
     }
 
     public void increaseLikeCount() {

--- a/src/main/java/com/sprint/deokhugam/domain/review/entity/Review.java
+++ b/src/main/java/com/sprint/deokhugam/domain/review/entity/Review.java
@@ -1,14 +1,19 @@
 package com.sprint.deokhugam.domain.review.entity;
 
 import com.sprint.deokhugam.domain.book.entity.Book;
+import com.sprint.deokhugam.domain.comment.entity.Comment;
 import com.sprint.deokhugam.domain.user.entity.User;
 import com.sprint.deokhugam.global.base.BaseUpdatableEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -47,6 +52,9 @@ public class Review extends BaseUpdatableEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
 
     public Review(Integer rating, String content, Book book, User user) {
         this.rating = rating;

--- a/src/main/java/com/sprint/deokhugam/global/config/WebMvcConfig.java
+++ b/src/main/java/com/sprint/deokhugam/global/config/WebMvcConfig.java
@@ -4,11 +4,13 @@ import com.sprint.deokhugam.global.interceptor.LoginInterceptor;
 import com.sprint.deokhugam.global.interceptor.MDCLoggingInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
+@Profile("!test")
 public class WebMvcConfig implements WebMvcConfigurer {
 
     private final LoginInterceptor loginInterceptor;

--- a/src/test/java/com/sprint/deokhugam/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/comment/controller/CommentControllerTest.java
@@ -35,12 +35,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(CommentController.class)
 @DisplayName("CommentController 슬라이스 테스트")
+@ActiveProfiles("test")
 class CommentControllerTest {
 
     @Autowired

--- a/src/test/java/com/sprint/deokhugam/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/comment/controller/CommentControllerTest.java
@@ -6,8 +6,10 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -387,5 +389,68 @@ class CommentControllerTest {
             .andExpect(jsonPath("$.totalElements").value(0))
             .andExpect(jsonPath("$.hasNext").value(false))
             .andDo(print());
+    }
+
+    @Test
+    @DisplayName("댓글을_논리삭제하면_204가_반환된다")
+    void 댓글을_논리삭제하면_204가_반환된다() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        willDoNothing().given(commentService).softDelete(commentId, userId);
+
+        // when
+        ResultActions result = mockMvc.perform(delete("/api/comments/{commentId}", commentId)
+                .header("Deokhugam-Request-User-ID", userId.toString()));
+
+        // then
+        result.andDo(print())
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("논리삭제된_댓글을_물리삭제하면_204가_반환된다")
+    void 논리삭제된_댓글을_물리삭제하면_204가_반환된다() throws Exception {
+        // Given
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        willDoNothing().given(commentService).hardDelete(commentId, userId);
+
+        // When
+        ResultActions result = mockMvc.perform(delete("/api/comments/{commentId}/hard", commentId)
+                .header("Deokhugam-Request-User-ID", userId.toString()));
+
+        // then
+        result.andDo(print())
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("삭제시_요청자_ID가_없으면_400이_반환된다")
+    void 삭제시_요청자_ID가_없으면_400이_반환된다() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+
+        // when
+        ResultActions result = mockMvc.perform(delete("/api/comments/{commentId}", commentId));
+
+        // then
+        result.andDo(print())
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("물리삭제시_요청자_ID가_없으면_400이_반환된다")
+    void 물리삭제시_요청자_ID가_없으면_400이_반환된다() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+
+        // when
+        ResultActions result = mockMvc.perform(delete("/api/comments/{commentId}/hard", commentId));
+
+        // then
+        result.andDo(print())
+            .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/sprint/deokhugam/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/comment/repository/CommentRepositoryTest.java
@@ -11,6 +11,7 @@ import com.sprint.deokhugam.global.config.JpaAuditingConfig;
 import com.sprint.deokhugam.global.config.QueryDslConfig;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -170,11 +171,34 @@ class CommentRepositoryTest {
         assertThat(result.hasNext()).isFalse();
     }
 
+    @Test
+    @DisplayName("findByIdIncludingDeleted - 삭제 여부 상관없이 댓글을 조회할 수 있다")
+    void findByIdIncludingDeleted_논리삭제된_댓글_조회() {
+        // Given
+        Comment comment = create("삭제된 댓글");
+        comment.softDelete(); // 논리삭제
+        em.persist(comment);
+        em.flush();
+        em.clear();
+
+        // When
+        Optional<Comment> result = commentRepository.findByIdIncludingDeleted(comment.getId());
+
+        // Then
+        assertThat(result).isPresent();
+        assertThat(result.get().getIsDeleted()).isTrue();
+    }
+
     private Comment createComment(String content, Instant createdAt) {
         Comment comment = new Comment(review1, user1, content);
         ReflectionTestUtils.setField(comment, "createdAt", createdAt);
         ReflectionTestUtils.setField(comment, "updatedAt", createdAt);
         ReflectionTestUtils.setField(comment, "isDeleted", false);
+        return comment;
+    }
+
+    private Comment create(String content) {
+        Comment comment = new Comment(review1, user1, content);
         return comment;
     }
 }

--- a/src/test/java/com/sprint/deokhugam/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/comment/repository/CommentRepositoryTest.java
@@ -25,11 +25,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DataJpaTest
 @Import({JpaAuditingConfig.class, QueryDslConfig.class})
-@ActiveProfiles("test")
+@ActiveProfiles("dev")
+@TestPropertySource(properties = "spring.sql.init.mode=never")
 @DisplayName("CommentRepository 단위 테스트")
 class CommentRepositoryTest {
 

--- a/src/test/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImplTest.java
@@ -485,6 +485,7 @@ public class CommentServiceImplTest {
     private static Comment createSoftDeleted(Review review, User user, String content) {
         Comment comment = new Comment(review, user, content);
         comment.softDelete();
+        ReflectionTestUtils.setField(comment, "id", UUID.randomUUID());
         return comment;
     }
 

--- a/src/test/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImplTest.java
@@ -3,9 +3,11 @@ package com.sprint.deokhugam.domain.comment.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.verify;
 
 import com.sprint.deokhugam.domain.book.entity.Book;
 import com.sprint.deokhugam.domain.comment.dto.data.CommentDto;
@@ -13,6 +15,7 @@ import com.sprint.deokhugam.domain.comment.dto.request.CommentCreateRequest;
 import com.sprint.deokhugam.domain.comment.dto.request.CommentUpdateRequest;
 import com.sprint.deokhugam.domain.comment.entity.Comment;
 import com.sprint.deokhugam.domain.comment.exception.CommentNotFoundException;
+import com.sprint.deokhugam.domain.comment.exception.CommentNotSoftDeletedException;
 import com.sprint.deokhugam.domain.comment.exception.InvalidCursorTypeException;
 import com.sprint.deokhugam.domain.comment.exception.CommentUnauthorizedAccessException;
 import com.sprint.deokhugam.domain.comment.mapper.CommentMapper;
@@ -24,6 +27,7 @@ import com.sprint.deokhugam.domain.user.entity.User;
 import com.sprint.deokhugam.domain.user.exception.UserNotFoundException;
 import com.sprint.deokhugam.domain.user.repository.UserRepository;
 import com.sprint.deokhugam.global.dto.response.CursorPageResponse;
+import com.sprint.deokhugam.global.exception.UnauthorizedException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -69,7 +73,6 @@ public class CommentServiceImplTest {
     private Comment comment1;
     private String content;
     private CommentDto expectedDto;
-
 
     @BeforeEach
     void 초기_설정() {
@@ -350,6 +353,119 @@ public class CommentServiceImplTest {
             .isInstanceOf(InvalidCursorTypeException.class);
     }
 
+    @Test
+    @DisplayName("댓글을_논리삭제하면_isDeleted가_true가_된다")
+    void 댓글을_논리삭제하면_isDeleted가_true가_된다() {
+        // Given
+        UUID commentId = comment1.getId();
+        given(commentRepository.findById(commentId))
+            .willReturn(Optional.of(comment1));
+
+        // When
+        commentService.softDelete(commentId, user1.getId());
+
+        // Then
+        verify(commentRepository).findById(comment1.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지_않는_댓글_논리삭제시_예외가_발생한다")
+    void 존재하지_않는_댓글_논리삭제시_예외가_발생한다() {
+        // Given
+        UUID nonExistentId = UUID.randomUUID();
+        given(commentRepository.findById(nonExistentId))
+            .willReturn(Optional.empty());
+
+        // When
+        Throwable result = catchThrowable(() ->
+            commentService.softDelete(nonExistentId, user1.getId()));
+
+        // Then
+        assertThat(result).isInstanceOf(CommentNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("권한없는_사용자가_댓글_논리삭제시_예외가_발생한다")
+    void 권한없는_사용자가_댓글_논리삭제시_예외가_발생한다() {
+        // Given
+        UUID reviewId = UUID.randomUUID();
+        UUID unauthorizedUserId = UUID.randomUUID();
+        given(commentRepository.findById(reviewId))
+            .willReturn(Optional.of(comment1));
+
+        // When
+        Throwable result = catchThrowable(() ->
+            commentService.softDelete(reviewId, unauthorizedUserId));
+
+        // Then
+        assertThat(result).isInstanceOf(CommentUnauthorizedAccessException.class);
+    }
+
+    @Test
+    @DisplayName("논리삭제된_댓글을_물리삭제하면_DB에서_완전히_삭제된다")
+    void 논리삭제된_댓글을_물리삭제하면_DB에서_완전히_삭제된다() {
+        // Given
+        UUID reviewId = UUID.randomUUID();
+        Comment softDeletedComment = createSoftDeleted(review1, user1, "댓1");
+
+        given(commentRepository.findByIdIncludingDeleted(reviewId))
+            .willReturn(Optional.of(softDeletedComment));
+
+        // When
+        commentService.hardDelete(reviewId, user1.getId());
+
+        // Then
+        verify(commentRepository).delete(softDeletedComment);
+    }
+
+    @Test
+    @DisplayName("존재하지_않는_댓글_물리삭제시_예외가_발생한다")
+    void 존재하지_않는_댓글_물리삭제시_예외가_발생한다() {
+        // Given
+        UUID nonExistentId = UUID.randomUUID();
+        given(commentRepository.findByIdIncludingDeleted(nonExistentId))
+            .willReturn(Optional.empty());
+
+        // When
+        Throwable result = catchThrowable(() ->
+            commentService.hardDelete(nonExistentId, user1.getId()));
+
+        // Then
+        assertThat(result).isInstanceOf(CommentNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("논리삭제되지_않은_댓글_물리삭제시_예외가_발생한다")
+    void 논리삭제되지_않은_댓글_물리삭제시_예외가_발생한다() {
+        // Given
+        given(commentRepository.findByIdIncludingDeleted(comment1.getId()))
+            .willReturn(Optional.of(comment1));
+
+        // When
+        Throwable result = catchThrowable(() ->
+            commentService.hardDelete(comment1.getId(), user1.getId()));
+
+        // Then
+        assertThat(result).isInstanceOf(CommentNotSoftDeletedException.class);
+    }
+
+    @Test
+    @DisplayName("권한없는_사용자가_댓글_물리삭제시_예외가_발생한다")
+    void 권한없는_사용자가_댓글_물리삭제시_예외가_발생한다() {
+        // Given
+        UUID unauthorizedUserId = UUID.randomUUID();
+        Comment softDeletedComment = createSoftDeleted(review1, user1, "댓1");
+        given(commentRepository.findByIdIncludingDeleted(softDeletedComment.getId()))
+            .willReturn(Optional.of(softDeletedComment));
+
+        // When
+        Throwable result = catchThrowable(() ->
+            commentService.hardDelete(softDeletedComment.getId(), unauthorizedUserId));
+
+        // Then
+        assertThat(result).isInstanceOf(CommentUnauthorizedAccessException.class);
+    }
+
     private CommentDto createDto(UUID reviewId, String content, Instant createdAt) {
         return CommentDto.builder()
             .id(UUID.randomUUID())
@@ -365,4 +481,11 @@ public class CommentServiceImplTest {
     private Comment create(Review review, User user, String content) {
         return new Comment(review, user, content);
     }
+
+    private static Comment createSoftDeleted(Review review, User user, String content) {
+        Comment comment = new Comment(review, user, content);
+        comment.softDelete();
+        return comment;
+    }
+
 }

--- a/src/test/java/com/sprint/deokhugam/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/review/controller/ReviewControllerTest.java
@@ -30,12 +30,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(ReviewController.class)
 @DisplayName("ReviewController 슬라이스 테스트")
+@ActiveProfiles("test")
 class ReviewControllerTest {
 
     @Autowired


### PR DESCRIPTION
## 📌 PR 요약
- 댓글 논리삭제, 물리삭제

## ✅ 작업 상세 내용
- [x] 댓글 논리삭제, 물리삭제
- [x] 테스트 코드 작성
-
## 🧪 테스트 방법
논리삭제안된 댓글 물리삭제 하려할 때
<img width="721" height="383" alt="image" src="https://github.com/user-attachments/assets/e7437669-5ecc-4326-bb54-704f84b786a9" />
<img width="757" height="770" alt="스크린샷 2025-07-18 015949" src="https://github.com/user-attachments/assets/a4f5b027-4646-4f9c-bd5c-24983fd22453" />



리뷰 레포에서 저거 하나만 오류가 나길래 해결해보고 올리려했는데 잘 모르겠어서 일단 뒀구용,,
<img width="1584" height="462" alt="스크린샷 2025-07-18 020119" src="https://github.com/user-attachments/assets/1b937321-0562-45c1-8360-69f1a3620b00" />



어쩌다 발견했는데 리뷰 하드삭제하려고 하면 댓글남아있을ㅇ때 안지워지드라거여,,
댓 없을때 지워짐
<img width="2566" height="667" alt="image" src="https://github.com/user-attachments/assets/f72d3d9a-d9d4-450a-9f5b-d58299b8e589" />

있을때 오류
<img width="1249" height="976" alt="image" src="https://github.com/user-attachments/assets/7218ed84-7017-46f3-891c-5da7fa0dc478" />

연관관계 설정해주니 잘 삭제됐습니단!
<img width="944" height="579" alt="image" src="https://github.com/user-attachments/assets/31496143-39b0-4c59-adf4-6a3d74b0ea70" />


## 📎 관련 이슈
- Close #123

## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 댓글에 대해 논리 삭제(soft delete) 및 물리 삭제(hard delete) 기능이 추가되었습니다. 이제 댓글을 삭제할 때 두 가지 방식 중 선택할 수 있습니다.

* **버그 수정**
  * 댓글 및 리뷰 수정 시, 입력값에 대한 유효성 검증 없이 값이 바로 반영되도록 변경되었습니다.

* **테스트**
  * 댓글 논리/물리 삭제 기능에 대한 단위 테스트 및 컨트롤러 테스트가 추가되었습니다.
  * 댓글 리포지토리의 삭제된 댓글 조회 기능에 대한 테스트가 추가되었습니다.
  * 리뷰 컨트롤러 테스트에 테스트 프로파일 적용이 명시되었습니다.

* **기타**
  * 일부 설정이 테스트 환경에서만 동작하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->