### PR TITLE
fix: 논리 삭제된 책에 리뷰가 있는 경우 전체 리뷰 불러올 때 발생한 오류 수정

### DIFF
--- a/src/main/java/com/sprint/deokhugam/domain/review/repository/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/sprint/deokhugam/domain/review/repository/CustomReviewRepositoryImpl.java
@@ -35,6 +35,9 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
         BooleanBuilder whereCondition = new BooleanBuilder();
         BooleanBuilder cursorCondition = new BooleanBuilder();
 
+        // 논리 삭제된 책의 리뷰는 가져오지 않음
+        whereCondition.and(review.book.isDeleted.eq(false));
+
         if (params.userId() != null || params.bookId() != null
             || params.keyword() != null) {
             whereCondition.and(filterByIdAndKeyword(review, params));
@@ -59,6 +62,9 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
         QReview review = QReview.review;
 
         BooleanBuilder whereCondition = new BooleanBuilder();
+
+        // 논리 삭제된 책의 리뷰는 가져오지 않음
+        whereCondition.and(review.book.isDeleted.eq(false));
 
         if (params.userId() != null || params.bookId() != null || params.keyword() != null) {
             whereCondition.and(filterByIdAndKeyword(review, params));


### PR DESCRIPTION
## 📌 PR 요약
- 리뷰 목록 조회 시 논리 삭제된 책에 리뷰가 있으면 전체 리뷰 목록 불러올 때 발생한 오류 수정

## ✅ 작업 상세 내용
- [x] `CustomReviewRepositoryImpl`에 `whereCondition.and(review.book.isDeleted.eq(false));` 추가

## 🧪 테스트 방법
- 

## 📎 관련 이슈
- 

## 추가 전달 사항