### PR TITLE
Add: 도서 API Swagger 추가 + mvc 패턴 수정

### DIFF
--- a/src/main/java/com/sprint/deokhugam/domain/book/controller/BookController.java
+++ b/src/main/java/com/sprint/deokhugam/domain/book/controller/BookController.java
@@ -2,6 +2,7 @@ package com.sprint.deokhugam.domain.book.controller;
 
 import com.sprint.deokhugam.domain.api.BookInfoProvider;
 import com.sprint.deokhugam.domain.api.dto.NaverBookDto;
+import com.sprint.deokhugam.domain.book.controller.api.BookApi;
 import com.sprint.deokhugam.domain.book.dto.data.BookDto;
 import com.sprint.deokhugam.domain.book.dto.request.BookCreateRequest;
 import com.sprint.deokhugam.domain.book.dto.request.BookSearchRequest;
@@ -37,12 +38,13 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/books")
 @RequiredArgsConstructor
 @Slf4j
-public class BookController {
+public class BookController implements BookApi {
 
     private final BookService bookService;
     private final BookInfoProvider provider;
     private final PopularBookService popularBookService;
 
+    @Override
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<BookDto> create(
         @Valid @RequestPart("bookData") BookCreateRequest bookData,
@@ -64,6 +66,7 @@ public class BookController {
      * @return 도서 목록 응답
      * */
 
+    @Override
     @GetMapping
     public ResponseEntity<CursorPageResponse<BookDto>> getBooks(
         @RequestParam(required = false) String keyword,
@@ -91,6 +94,7 @@ public class BookController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @Override
     @GetMapping("/{bookId}")
     public ResponseEntity<BookDto> getBook(@PathVariable UUID bookId) {
         log.info("[BookController] 도서 상세 정보 요청 - id: {}", bookId);
@@ -100,6 +104,7 @@ public class BookController {
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
+    @Override
     @GetMapping("/info")
     public ResponseEntity<NaverBookDto> getBookInfoByIsbn(@RequestParam String isbn) {
         log.info("[BookController] 도서 정보 조회 요청 - isbn: {}", isbn);
@@ -109,7 +114,8 @@ public class BookController {
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
-    @PatchMapping("/{bookId}")
+    @Override
+    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, path ="/{bookId}")
     public ResponseEntity<BookDto> update(
         @PathVariable UUID bookId,
         @Valid @RequestPart("bookData") BookUpdateRequest bookData,
@@ -130,6 +136,7 @@ public class BookController {
      * @return 인식된 ISBN 문자열
      * @throws OcrException OCR 처리 중 오류 발생 시
      * */
+    @Override
     @PostMapping("/isbn/ocr")
     public ResponseEntity<String> extractIsbnFromImage(
         @RequestPart(value = "image") MultipartFile image
@@ -147,6 +154,7 @@ public class BookController {
             .body(extractedIsbn);
     }
 
+    @Override
     @DeleteMapping("/{bookId}")
     public ResponseEntity<Void> delete(@PathVariable UUID bookId) {
         log.info("[BookController] 도서 논리 삭제 요청 - id: {}", bookId);
@@ -156,6 +164,7 @@ public class BookController {
         return ResponseEntity.noContent().build();
     }
 
+    @Override
     @DeleteMapping("/{bookId}/hard")
     public ResponseEntity<Void> hardDelete(@PathVariable UUID bookId) {
         log.info("[BookController] 도서 물리 삭제 요청 - id: {}", bookId);
@@ -163,6 +172,7 @@ public class BookController {
         return ResponseEntity.noContent().build();
     }
 
+    @Override
     @GetMapping("/popular")
     public ResponseEntity<CursorPageResponse<PopularBookDto>> getPopularBooks(
         @ModelAttribute PopularBookGetRequest request

--- a/src/main/java/com/sprint/deokhugam/domain/book/controller/api/BookApi.java
+++ b/src/main/java/com/sprint/deokhugam/domain/book/controller/api/BookApi.java
@@ -1,0 +1,390 @@
+package com.sprint.deokhugam.domain.book.controller.api;
+
+import com.sprint.deokhugam.domain.api.dto.NaverBookDto;
+import com.sprint.deokhugam.domain.book.dto.data.BookDto;
+import com.sprint.deokhugam.domain.book.dto.request.BookCreateRequest;
+import com.sprint.deokhugam.domain.book.dto.request.BookUpdateRequest;
+import com.sprint.deokhugam.domain.book.exception.OcrException;
+import com.sprint.deokhugam.domain.popularbook.dto.data.PopularBookDto;
+import com.sprint.deokhugam.domain.popularbook.dto.request.PopularBookGetRequest;
+import com.sprint.deokhugam.global.dto.response.CursorPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.io.IOException;
+import java.util.UUID;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+
+@Tag(name = "도서 관리", description = "도서 관련 API")
+public interface BookApi {
+
+    @Operation(summary = "도서 등록", description = "새로운 도서를 등록합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "201",
+            description = "도서 등록 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = BookDto.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청(입력값 검증 실패, ISBN 형식 오류 등)",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "ISBN 중복",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    ResponseEntity<BookDto> create(
+        @Parameter(description = "도서 정보")
+        @Valid @RequestPart("bookData") BookCreateRequest bookData,
+
+        @Parameter(description = "도서 썸네일 이미지",
+            schema = @Schema(type = "string", format = "binary"))
+        @RequestPart(value = "thumbnailImage", required = false) MultipartFile thumbnailImage)
+        throws IOException;
+
+    @Operation(summary = "도서 목록 조회", description = "검색 조건에 맞는 도서 목록을 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "도서 목록 조회 성공",
+            content = @Content(
+                mediaType = "*/*",
+                array = @ArraySchema(schema = @Schema(implementation = BookDto.class))
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청(정렬 기준 오류, 페이지네이션 파라미터 오류 등)",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    @GetMapping
+    ResponseEntity<CursorPageResponse<BookDto>> getBooks(
+        @Parameter(description = "도서 제목| 저자 | ISBN", example = "자바의 정석")
+        @RequestParam(required = false) String keyword,
+
+        @Parameter(description = "정렬 기준(title| publishedDate | rating | reviewCount",
+            example = "title")
+        @RequestParam(defaultValue = "title") String orderBy,
+
+        @Parameter(description = "정렬 방향 (ASC or DESC)",
+            example = "DESC")
+        @RequestParam(defaultValue = "DESC") String direction,
+
+        @Parameter(description = "커서 페이지네이션 커서")
+        @RequestParam(required = false) String cursor,
+
+        @Parameter(description = "보조 커서(createdAt)")
+        @RequestParam(required = false) Long after,
+
+        @Parameter(description = "페이지 크기", example = "50")
+        @RequestParam(defaultValue = "50") Integer limit
+    );
+
+    @Operation(summary = "도서 정보 상세 조회", description = "도서 상세 정보 조회")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "도서 정보 조회 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = BookDto.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "도서 정보 없음",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    @GetMapping("/{bookId}")
+    ResponseEntity<BookDto> getBook(
+        @Parameter(description = "도서 ID", example = "9a4d6e2b-8f53-4c8c-a7c7-21d5079b8b37")
+        @PathVariable UUID bookId);
+
+    @Operation(summary = "ISBN으로 도서 정보 조회",
+        description = "Naver API를 통해 ISBN으로 도서 정보를 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "도서 정보 조회 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = NaverBookDto.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 ISBN 형식",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "도서 정보 없음",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    @GetMapping("/info")
+    ResponseEntity<NaverBookDto> getBookInfoByIsbn(
+        @Parameter(description = "ISBN 번호", example = "9788968481901")
+        @RequestParam String isbn);
+
+    @Operation(summary = "도서 정보 수정", description = "도서 정보를 수정합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "도서 정보 수정 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = BookDto.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청(입력값 검증 실패, ISBN 형식 오류 등)",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "도서 정보 없음",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "409",
+            description = "ISBN 중복",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    @PatchMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, path = "/{bookId}")
+    ResponseEntity<BookDto> update(
+        @Parameter(description = "도서 ID", example = "9a4d6e2b-8f53-4c8c-a7c7-21d5079b8b37")
+        @PathVariable UUID bookId,
+
+        @Parameter(description = "수정할 도서 정보")
+        @Valid @RequestPart("bookData") BookUpdateRequest bookData,
+
+        @Parameter(description = "수정할 도서 썸네일 이미지")
+        @RequestPart(value = "thumbnailImage", required = false) MultipartFile thumbnailImage
+    ) throws IOException;
+
+    @Operation(summary = "이미지 기반 ISBN 인식",
+        description = "도서 이미지를 통해 ISBN을 인식합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "ISBN 인식 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = String.class),
+                examples = {
+                    @ExampleObject(
+                        name = "성공 예시",
+                        summary = "ISBN 번호 예시",
+                        value = "9788968481901"
+                    )
+                }
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 이미지 형식 또는 OCR 인식 실패",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    @PostMapping("/isbn/ocr")
+    ResponseEntity<String> extractIsbnFromImage(
+        @Parameter(description = "도서 이미지",
+            schema = @Schema(type = "string", format = "binary"))
+        @RequestPart(value = "image") MultipartFile image
+    ) throws OcrException;
+
+    @Operation(summary = "도서 논리 삭제",
+        description = "도서를 논리적으로 삭제합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description = "도서 삭제 성공"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "도서 정보 없음"
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류"
+        )
+    })
+    @DeleteMapping("/{bookId}")
+    ResponseEntity<Void> delete(
+        @Parameter(description = "도서 ID",
+            example = "9a4d6e2b-8f53-4c8c-a7c7-21d5079b8b37")
+        @PathVariable UUID bookId);
+
+    @Operation(summary = "도서 물리 삭제",
+        description = "도서를 물리적으로 삭제합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description = "도서 삭제 성공"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "도서 정보 없음"
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류"
+        )
+    })
+    @DeleteMapping("/{bookId}/hard")
+    ResponseEntity<Void> hardDelete(
+        @Parameter(description = "도서 ID",
+            example = "9a4d6e2b-8f53-4c8c-a7c7-21d5079b8b37")
+        @PathVariable UUID bookId);
+
+    @Operation(summary = "인기 도서 목록 조회",
+        description = "기간별 인기 도서 목록을 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "인기 도서 목록 조회 성공",
+            content = @Content(
+                mediaType = "*/*",
+                array = @ArraySchema(schema = @Schema(implementation = PopularBookDto.class))
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청(랭킹 기간 오류, 정렬 방향 오류 등)",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    @GetMapping("/popular")
+    ResponseEntity<CursorPageResponse<PopularBookDto>> getPopularBooks(
+        @Parameter(
+            description = """
+                인기 도서 목록 조회용 DTO<br>
+                - **period**: 랭킹 기간 (DAILY, WEEKLY, MONTHLY, ALL_TIME, 기본값: DAILY)<br>
+                - **direction**: 정렬 방향 (ASC, DESC, 기본값: ASC)<br>
+                - **cursor**: 커서 페이지네이션을 위한 커서 값 (인기 도서 순위)<br>
+                - **after**: createdAt 기준 보조 커서<br>
+                - **limit**: 페이지 크기 (기본값: 50)
+                """
+        )
+        @ModelAttribute PopularBookGetRequest request);
+}

--- a/src/main/java/com/sprint/deokhugam/global/config/WebMvcConfig.java
+++ b/src/main/java/com/sprint/deokhugam/global/config/WebMvcConfig.java
@@ -21,8 +21,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addInterceptor(mdcLoggingInterceptor)
             .addPathPatterns("/api/**");
 
+        // 로그인, 회원가입, 대시보드 관련 api만 허용
         registry.addInterceptor(loginInterceptor)
                 .addPathPatterns("/api/**")
-                    .excludePathPatterns("/api/users/login", "/api/users"); // 로그인 회원가입 요청만 허용
+                    .excludePathPatterns("/api/users/login", "/api/users",
+                        "/api/users/power", "/api/books/popular", "/api/reviews/popular");
     }
 }


### PR DESCRIPTION
## 📌 PR 요약
- 도서 API Swagger 추가 및 mvc 패턴 수정

## ✅ 작업 상세 내용
- [x] 도서 API Swagger 추가
- [x] 로그인하지 않아도 대시보드 관련 데이터 볼 수 있도록 mvc 패턴 수정

## 🧪 테스트 방법
<img width="1412" height="557" alt="image" src="https://github.com/user-attachments/assets/a4014bc8-835f-40ac-a934-a2230dac7e9f" />

<img width="1036" height="703" alt="image" src="https://github.com/user-attachments/assets/ffb404c6-0b56-481d-a871-934141da5f48" />

## 📎 관련 이슈

## 추가 전달 사항

대시보드 관련 api들이 User-ID 가 없으면 접근이 안돼서 아마 이 pr에서 작업 할거 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 도서 관리 REST API 인터페이스가 추가되어, 도서 생성, 조회, 수정, 삭제, 인기 도서 조회, ISBN 이미지 추출 등 다양한 도서 관련 기능을 제공합니다.

* **리팩터링**
  * 도서 컨트롤러가 새로운 API 인터페이스를 구현하도록 구조가 개선되었습니다.
  * 일부 엔드포인트의 요청 형식 및 경로 명시가 명확해졌습니다.

* **기타**
  * 로그인 인터셉터 설정이 업데이트되어 특정 인기 도서 및 리뷰 API가 로그인 없이 접근 가능하도록 제외되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->