### PR TITLE
Fix: 인기 리뷰 순위 조회 

### DIFF
--- a/src/main/java/com/sprint/deokhugam/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/repository/CommentRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface CommentRepository extends JpaRepository<Comment, UUID> {
+public interface CommentRepository extends JpaRepository<Comment, UUID>, CommentRepositoryCustom {
 
     @EntityGraph(attributePaths = {"user"})
     Slice<Comment> findByReviewId(UUID reviewId, Pageable pageable);

--- a/src/main/java/com/sprint/deokhugam/domain/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/repository/CommentRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.sprint.deokhugam.domain.comment.repository;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+public interface CommentRepositoryCustom {
+
+    Map<UUID, Long> countByReviewIdBetween(Instant start, Instant end);
+}

--- a/src/main/java/com/sprint/deokhugam/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/repository/CommentRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.sprint.deokhugam.domain.comment.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.deokhugam.domain.comment.entity.QComment;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private static final QComment comment = QComment.comment;
+    
+    @Override
+    public Map<UUID, Long> countByReviewIdBetween(Instant start, Instant end) {
+
+        return queryFactory
+            .select(comment.review.id, comment.count())
+            .from(comment)
+            .where(
+                comment.createdAt.gt(start),
+                comment.createdAt.lt(end),
+                comment.isDeleted.isFalse()
+            )
+            .groupBy(comment.review.id)
+            .fetch()
+            .stream()
+            .collect(Collectors.toMap(
+                tuple -> tuple.get(comment.review.id),
+                tuple -> tuple.get(comment.count())
+            ));
+    }
+}

--- a/src/main/java/com/sprint/deokhugam/domain/popularreview/batch/ReviewBatch.java
+++ b/src/main/java/com/sprint/deokhugam/domain/popularreview/batch/ReviewBatch.java
@@ -2,15 +2,12 @@ package com.sprint.deokhugam.domain.popularreview.batch;
 
 import com.sprint.deokhugam.domain.comment.repository.CommentRepository;
 import com.sprint.deokhugam.domain.popularreview.service.PopularReviewService;
-import com.sprint.deokhugam.domain.review.entity.Review;
-import com.sprint.deokhugam.domain.review.repository.ReviewRepository;
 import com.sprint.deokhugam.domain.reviewlike.repository.ReviewLikeRepository;
 import com.sprint.deokhugam.global.batch.BatchListener;
 import com.sprint.deokhugam.global.enums.PeriodType;
 import com.sprint.deokhugam.global.exception.BatchAlreadyRunException;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/sprint/deokhugam/domain/popularreview/dto/data/ReviewScoreDto.java
+++ b/src/main/java/com/sprint/deokhugam/domain/popularreview/dto/data/ReviewScoreDto.java
@@ -1,0 +1,12 @@
+package com.sprint.deokhugam.domain.popularreview.dto.data;
+
+import com.sprint.deokhugam.domain.review.entity.Review;
+
+public record ReviewScoreDto(
+    Review review,
+    Long commentCount,
+    Long likeCount,
+    Double score
+) {
+
+}

--- a/src/main/java/com/sprint/deokhugam/domain/popularreview/service/PopularReviewService.java
+++ b/src/main/java/com/sprint/deokhugam/domain/popularreview/service/PopularReviewService.java
@@ -2,7 +2,6 @@ package com.sprint.deokhugam.domain.popularreview.service;
 
 import com.sprint.deokhugam.domain.popularreview.dto.data.PopularReviewDto;
 import com.sprint.deokhugam.domain.popularreview.entity.PopularReview;
-import com.sprint.deokhugam.domain.review.entity.Review;
 import com.sprint.deokhugam.global.dto.response.CursorPageResponse;
 import com.sprint.deokhugam.global.enums.PeriodType;
 import java.time.Instant;
@@ -26,6 +25,6 @@ public interface PopularReviewService {
     void validateJobNotDuplicated(Instant referenceTime);
 
 
-    void savePopularReviewsByPeriod(PeriodType period, Instant today,
+    List<PopularReview> savePopularReviewsByPeriod(PeriodType period, Instant today,
         Map<UUID, Long> commentMap, Map<UUID, Long> likeMap, StepContribution contribution);
 }

--- a/src/main/java/com/sprint/deokhugam/domain/popularreview/service/PopularReviewService.java
+++ b/src/main/java/com/sprint/deokhugam/domain/popularreview/service/PopularReviewService.java
@@ -7,6 +7,8 @@ import com.sprint.deokhugam.global.dto.response.CursorPageResponse;
 import com.sprint.deokhugam.global.enums.PeriodType;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.data.domain.Sort;
 
@@ -24,6 +26,6 @@ public interface PopularReviewService {
     void validateJobNotDuplicated(Instant referenceTime);
 
 
-    List<PopularReview> savePopularReviewsByPeriod(List<Review> totalReviews,
-        PeriodType period, StepContribution contribution, Instant today);
+    void savePopularReviewsByPeriod(PeriodType period, Instant today,
+        Map<UUID, Long> commentMap, Map<UUID, Long> likeMap, StepContribution contribution);
 }

--- a/src/main/java/com/sprint/deokhugam/domain/popularreview/service/PopularReviewServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugam/domain/popularreview/service/PopularReviewServiceImpl.java
@@ -14,7 +14,6 @@ import com.sprint.deokhugam.global.exception.BatchAlreadyRunException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -23,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.StepContribution;
@@ -110,7 +108,7 @@ public class PopularReviewServiceImpl implements PopularReviewService {
 
     /* 배치에서 사용 */
     @Transactional
-    public void savePopularReviewsByPeriod(PeriodType period, Instant today,
+    public List<PopularReview> savePopularReviewsByPeriod(PeriodType period, Instant today,
         Map<UUID, Long> commentMap, Map<UUID, Long> likeMap, StepContribution contribution) {
 
         Set<UUID> reviewIds = new HashSet<>();
@@ -148,5 +146,7 @@ public class PopularReviewServiceImpl implements PopularReviewService {
         popularReviewRepository.saveAll(result);
         //batch meta 테이블에 결과 저장
         contribution.incrementWriteCount(result.size());
+
+        return result;
     }
 }

--- a/src/main/java/com/sprint/deokhugam/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sprint/deokhugam/domain/review/repository/ReviewRepository.java
@@ -20,8 +20,4 @@ public interface ReviewRepository extends JpaRepository<Review, UUID>, CustomRev
 
     @Query("SELECT AVG(r.rating) FROM Review r WHERE r.book = :book")
     Double findAverageRatingByBook(@Param("book") Book book);
-
-    /* 배치에서 사용 */
-    @Query(value = "SELECT * FROM reviews WHERE (comment_count*0.7 + like_count*0.3) > 0 AND is_deleted = false ORDER BY (comment_count*0.7 + like_count*0.3) DESC ", nativeQuery = true)
-    List<Review> findAllByCommentCountAndLikeCountWithSorting();
 }

--- a/src/main/java/com/sprint/deokhugam/domain/reviewlike/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/sprint/deokhugam/domain/reviewlike/repository/ReviewLikeRepository.java
@@ -4,7 +4,8 @@ import com.sprint.deokhugam.domain.reviewlike.entity.ReviewLike;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReviewLikeRepository extends JpaRepository<ReviewLike, UUID> {
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, UUID>,
+    ReviewLikeRepositoryCustom {
 
     boolean existsByReviewIdAndUserId(UUID reviewId, UUID userId);
 

--- a/src/main/java/com/sprint/deokhugam/domain/reviewlike/repository/ReviewLikeRepositoryCustom.java
+++ b/src/main/java/com/sprint/deokhugam/domain/reviewlike/repository/ReviewLikeRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.sprint.deokhugam.domain.reviewlike.repository;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+public interface ReviewLikeRepositoryCustom {
+
+    Map<UUID, Long> countByReviewIdBetween(Instant start, Instant end);
+}

--- a/src/main/java/com/sprint/deokhugam/domain/reviewlike/repository/ReviewLikeRepositoryImpl.java
+++ b/src/main/java/com/sprint/deokhugam/domain/reviewlike/repository/ReviewLikeRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.sprint.deokhugam.domain.reviewlike.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.deokhugam.domain.reviewlike.entity.QReviewLike;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ReviewLikeRepositoryImpl implements ReviewLikeRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private static final QReviewLike reviewLike = QReviewLike.reviewLike;
+
+    // 특정 기간 동안 리뷰에 눌린 좋아요 개수
+    @Override
+    public Map<UUID, Long> countByReviewIdBetween(Instant start, Instant end) {
+
+        return queryFactory
+            .select(reviewLike.review.id, reviewLike.count())
+            .from(reviewLike)
+            .where(
+                reviewLike.createdAt.gt(start),
+                reviewLike.createdAt.lt(end)
+            )
+            .groupBy(reviewLike.review.id)
+            .fetch()
+            .stream()
+            .collect(Collectors.toMap(
+                tuple -> tuple.get(reviewLike.review.id),
+                tuple -> tuple.get(reviewLike.count())
+            ));
+    }
+}

--- a/src/test/java/com/sprint/deokhugam/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/comment/repository/CommentRepositoryTest.java
@@ -2,6 +2,7 @@ package com.sprint.deokhugam.domain.comment.repository;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.sprint.deokhugam.domain.book.entity.Book;
 import com.sprint.deokhugam.domain.comment.entity.Comment;
@@ -11,6 +12,7 @@ import com.sprint.deokhugam.global.config.JpaAuditingConfig;
 import com.sprint.deokhugam.global.config.QueryDslConfig;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -189,6 +191,25 @@ class CommentRepositoryTest {
         // Then
         assertThat(result).isPresent();
         assertThat(result.get().getIsDeleted()).isTrue();
+    }
+
+    @Test
+    void 특정_기간_동안_추가_된_댓글_개수_테스트() {
+
+        // given
+        Instant start = Instant.MIN;
+        Instant end = Instant.MAX;
+        Comment comment = createComment("테스트용", Instant.now());
+        em.persist(comment);
+        em.flush();
+        em.clear();
+
+        // when
+        Map<UUID, Long> result = commentRepository.countByReviewIdBetween(start, end);
+
+        // then
+        assertEquals(1, result.size());
+        assert(result.values().contains(1L));
     }
 
     private Comment createComment(String content, Instant createdAt) {

--- a/src/test/java/com/sprint/deokhugam/domain/popularreview/service/PopularReviewServiceTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/popularreview/service/PopularReviewServiceTest.java
@@ -126,153 +126,153 @@ public class PopularReviewServiceTest {
             .isInstanceOf(BatchAlreadyRunException.class);
     }
 
-    @Test
-    void 전체기간_기준으로_인기리뷰를_저장한다() {
-        //given
-        Review review1 = createReview(1L, 1L, "2025-01-03T00:00:00Z");
-        Review review2 = createReview(3L, 3L, "2025-06-03T00:00:00Z");
-        Review review3 = createReview(2L, 2L, "2025-07-22T00:00:00Z");
-        List<Review> totalReviews = List.of(
-            review1,
-            review2,
-            review3
-        );
-        List<PopularReview> expectedPopularReviews = List.of(
-            createPopularReview(review1, PeriodType.ALL_TIME, 1L,
-                review1.getCommentCount() * 0.7 + review1.getLikeCount() * 0.3),
-            createPopularReview(review2, PeriodType.ALL_TIME, 2L,
-                review2.getCommentCount() * 0.7 + review2.getLikeCount() * 0.3),
-            createPopularReview(review3, PeriodType.ALL_TIME, 3L,
-                review3.getCommentCount() * 0.7 + review3.getLikeCount() * 0.3)
-        );
-
-        // when
-        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(totalReviews,
-            PeriodType.ALL_TIME,
-            contribution, Instant.now());
-
-        // then
-        assertThat(result).hasSize(3);
-        assertThat(result.get(0).getRank()).isEqualTo(1L);
-        assertThat(result.get(0).getScore()).isEqualTo(1L * 0.7 + 1L * 0.3);
-        then(popularReviewRepository).should().saveAll(any());
-        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
-    }
-
-    @Test
-    void 월기간_기준으로_인기리뷰를_저장한다() {
-        //given
-        Review review1 = createReview(1L, 1L, "2025-07-03T00:00:00Z");
-        Review notInPeriodReview = createReview(3L, 3L, "2025-06-01T00:00:00Z");
-        Review review3 = createReview(2L, 2L, "2025-07-22T00:00:00Z");
-        List<Review> totalReviews = List.of(
-            review3,
-            notInPeriodReview,
-            review1
-        );
-        List<PopularReview> expectedPopularReviews = List.of(
-            createPopularReview(review3, PeriodType.ALL_TIME, 1L,
-                review3.getCommentCount() * 0.7 + review3.getLikeCount() * 0.3),
-            createPopularReview(review1, PeriodType.ALL_TIME, 2L,
-                review1.getCommentCount() * 0.7 + review1.getLikeCount() * 0.3)
-        );
-
-        // when
-        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(totalReviews,
-            PeriodType.MONTHLY, contribution, Instant.parse("2025-07-23T00:00:00Z"));
-
-        // then
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getRank()).isEqualTo(1L);
-        assertThat(result.get(0).getScore()).isEqualTo(
-            review3.getCommentCount() * 0.7 + review3.getLikeCount() * 0.3);
-        then(popularReviewRepository).should().saveAll(any());
-        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
-    }
-
-    @Test
-    @DisplayName("주간 인기리뷰:7/18~7/24일 데이터를 가져온다(한국시간기준)")
-    void 주기간_기준으로_인기리뷰를_저장한다() {
-        //given
-        Instant currentTime = Instant.parse("2025-07-24T15:05:00Z"); // 한국시간 7/25일 00:05
-        Review notInPeriodReview1 = createReview(3L, 3L, "2025-06-01T00:00:00Z");
-        Review notInPeriodReview2 = createReview(2L, 2L,
-            "2025-07-17T14:49:00Z"); // 한국시간 7/17일 23:59
-        Review notInPeriodReview3 = createReview(2L, 2L,
-            "2025-07-25T15:00:00Z"); // 한국시간 7/26일 00:00
-
-        Review review1 = createReview(1L, 1L, "2025-07-17T15:00:00Z");  // 한국시간 7/18일 00:00
-        Review review2 = createReview(2L, 2L, "2025-07-24T14:49:00Z");  // 한국시간 7/24일 23:59
-        Review reviewToday1 = createReview(3L, 3L, "2025-07-24T15:00:00Z");  // 한국시간 7/25일 00:00
-        Review reviewToday2 = createReview(4L, 4L, "2025-07-25T14:59:59Z");  // 한국시간 7/25일 23:59
-
-        List<Review> totalReviews = List.of(
-            notInPeriodReview1,
-            notInPeriodReview2,
-            notInPeriodReview3,
-            reviewToday2,
-            reviewToday1,
-            review2,
-            review1
-        );
-        List<PopularReview> expectedPopularReviews = List.of(
-            createPopularReview(review2, PeriodType.WEEKLY, 1L, 2.0),
-            createPopularReview(review1, PeriodType.WEEKLY, 2L, 1.0)
-        );
-
-        // when
-        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(totalReviews,
-            PeriodType.WEEKLY, contribution, currentTime);
-
-        // then
-        assertThat(result).hasSize(2);
-        assertThat(result.get(1).getRank()).isEqualTo(2L);
-        assertThat(result.get(1).getScore()).isEqualTo(1.0);
-        then(popularReviewRepository).should().saveAll(any());
-        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
-
-    }
-
-    @Test
-    @DisplayName("일간 인기리뷰:7/24일 데이터를 가져온다(한국시간기준)")
-    void 일기간_기준으로_인기리뷰를_저장한다() {
-
-        //given
-        Instant currentTime = Instant.parse("2025-07-24T15:05:00Z"); // 한국시간 7/25일 00:05
-        Review notInPeriodReview1 = createReview(3L, 3L, "2025-06-01T00:00:00Z");
-        Review notInPeriodReview2 = createReview(2L, 2L,
-            "2025-07-23T14:59:00Z"); // 한국시간 7/23일 23:59
-        Review reviewYesterday1 = createReview(1L, 1L, "2025-07-23T15:00:00Z");  // 한국시간 7/24일 00:00
-        Review reviewYesterday2 = createReview(2L, 2L, "2025-07-24T14:59:00Z");  // 한국시간 7/24일 23:59
-        Review reviewToday1 = createReview(3L, 3L, "2025-07-24T15:00:00Z");  // 한국시간 7/25일 00:00
-        Review reviewToday2 = createReview(4L, 4L, "2025-07-25T14:59:59Z");  // 한국시간 7/25일 23:59
-
-        List<Review> totalReviews = List.of(
-            notInPeriodReview1,
-            notInPeriodReview2,
-            reviewYesterday2,
-            reviewYesterday1,
-            reviewToday1,
-            reviewToday2
-        );
-        List<PopularReview> expectedPopularReviews = List.of(
-            createPopularReview(reviewYesterday2, PeriodType.DAILY, 1L, 2.0),
-            createPopularReview(reviewYesterday1, PeriodType.DAILY, 2L, 1.0)
-        );
-
-        // when
-        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(totalReviews,
-            PeriodType.DAILY, contribution, currentTime);
-
-        // then
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getRank()).isEqualTo(1L);
-        assertThat(result.get(0).getScore()).isEqualTo(2.0);
-        assertThat(result.get(1).getRank()).isEqualTo(2L);
-        assertThat(result.get(1).getScore()).isEqualTo(1.0);
-        then(popularReviewRepository).should().saveAll(any());
-        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
-    }
+//    @Test
+//    void 전체기간_기준으로_인기리뷰를_저장한다() {
+//        //given
+//        Review review1 = createReview(1L, 1L, "2025-01-03T00:00:00Z");
+//        Review review2 = createReview(3L, 3L, "2025-06-03T00:00:00Z");
+//        Review review3 = createReview(2L, 2L, "2025-07-22T00:00:00Z");
+//        List<Review> totalReviews = List.of(
+//            review1,
+//            review2,
+//            review3
+//        );
+//        List<PopularReview> expectedPopularReviews = List.of(
+//            createPopularReview(review1, PeriodType.ALL_TIME, 1L,
+//                review1.getCommentCount() * 0.7 + review1.getLikeCount() * 0.3),
+//            createPopularReview(review2, PeriodType.ALL_TIME, 2L,
+//                review2.getCommentCount() * 0.7 + review2.getLikeCount() * 0.3),
+//            createPopularReview(review3, PeriodType.ALL_TIME, 3L,
+//                review3.getCommentCount() * 0.7 + review3.getLikeCount() * 0.3)
+//        );
+//
+//        // when
+//        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(totalReviews,
+//            PeriodType.ALL_TIME,
+//            contribution, Instant.now());
+//
+//        // then
+//        assertThat(result).hasSize(3);
+//        assertThat(result.get(0).getRank()).isEqualTo(1L);
+//        assertThat(result.get(0).getScore()).isEqualTo(1L * 0.7 + 1L * 0.3);
+//        then(popularReviewRepository).should().saveAll(any());
+//        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
+//    }
+//
+//    @Test
+//    void 월기간_기준으로_인기리뷰를_저장한다() {
+//        //given
+//        Review review1 = createReview(1L, 1L, "2025-07-03T00:00:00Z");
+//        Review notInPeriodReview = createReview(3L, 3L, "2025-06-01T00:00:00Z");
+//        Review review3 = createReview(2L, 2L, "2025-07-22T00:00:00Z");
+//        List<Review> totalReviews = List.of(
+//            review3,
+//            notInPeriodReview,
+//            review1
+//        );
+//        List<PopularReview> expectedPopularReviews = List.of(
+//            createPopularReview(review3, PeriodType.ALL_TIME, 1L,
+//                review3.getCommentCount() * 0.7 + review3.getLikeCount() * 0.3),
+//            createPopularReview(review1, PeriodType.ALL_TIME, 2L,
+//                review1.getCommentCount() * 0.7 + review1.getLikeCount() * 0.3)
+//        );
+//
+//        // when
+//        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(totalReviews,
+//            PeriodType.MONTHLY, contribution, Instant.parse("2025-07-23T00:00:00Z"));
+//
+//        // then
+//        assertThat(result).hasSize(2);
+//        assertThat(result.get(0).getRank()).isEqualTo(1L);
+//        assertThat(result.get(0).getScore()).isEqualTo(
+//            review3.getCommentCount() * 0.7 + review3.getLikeCount() * 0.3);
+//        then(popularReviewRepository).should().saveAll(any());
+//        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
+//    }
+//
+//    @Test
+//    @DisplayName("주간 인기리뷰:7/18~7/24일 데이터를 가져온다(한국시간기준)")
+//    void 주기간_기준으로_인기리뷰를_저장한다() {
+//        //given
+//        Instant currentTime = Instant.parse("2025-07-24T15:05:00Z"); // 한국시간 7/25일 00:05
+//        Review notInPeriodReview1 = createReview(3L, 3L, "2025-06-01T00:00:00Z");
+//        Review notInPeriodReview2 = createReview(2L, 2L,
+//            "2025-07-17T14:49:00Z"); // 한국시간 7/17일 23:59
+//        Review notInPeriodReview3 = createReview(2L, 2L,
+//            "2025-07-25T15:00:00Z"); // 한국시간 7/26일 00:00
+//
+//        Review review1 = createReview(1L, 1L, "2025-07-17T15:00:00Z");  // 한국시간 7/18일 00:00
+//        Review review2 = createReview(2L, 2L, "2025-07-24T14:49:00Z");  // 한국시간 7/24일 23:59
+//        Review reviewToday1 = createReview(3L, 3L, "2025-07-24T15:00:00Z");  // 한국시간 7/25일 00:00
+//        Review reviewToday2 = createReview(4L, 4L, "2025-07-25T14:59:59Z");  // 한국시간 7/25일 23:59
+//
+//        List<Review> totalReviews = List.of(
+//            notInPeriodReview1,
+//            notInPeriodReview2,
+//            notInPeriodReview3,
+//            reviewToday2,
+//            reviewToday1,
+//            review2,
+//            review1
+//        );
+//        List<PopularReview> expectedPopularReviews = List.of(
+//            createPopularReview(review2, PeriodType.WEEKLY, 1L, 2.0),
+//            createPopularReview(review1, PeriodType.WEEKLY, 2L, 1.0)
+//        );
+//
+//        // when
+//        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(totalReviews,
+//            PeriodType.WEEKLY, contribution, currentTime);
+//
+//        // then
+//        assertThat(result).hasSize(2);
+//        assertThat(result.get(1).getRank()).isEqualTo(2L);
+//        assertThat(result.get(1).getScore()).isEqualTo(1.0);
+//        then(popularReviewRepository).should().saveAll(any());
+//        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
+//
+//    }
+//
+//    @Test
+//    @DisplayName("일간 인기리뷰:7/24일 데이터를 가져온다(한국시간기준)")
+//    void 일기간_기준으로_인기리뷰를_저장한다() {
+//
+//        //given
+//        Instant currentTime = Instant.parse("2025-07-24T15:05:00Z"); // 한국시간 7/25일 00:05
+//        Review notInPeriodReview1 = createReview(3L, 3L, "2025-06-01T00:00:00Z");
+//        Review notInPeriodReview2 = createReview(2L, 2L,
+//            "2025-07-23T14:59:00Z"); // 한국시간 7/23일 23:59
+//        Review reviewYesterday1 = createReview(1L, 1L, "2025-07-23T15:00:00Z");  // 한국시간 7/24일 00:00
+//        Review reviewYesterday2 = createReview(2L, 2L, "2025-07-24T14:59:00Z");  // 한국시간 7/24일 23:59
+//        Review reviewToday1 = createReview(3L, 3L, "2025-07-24T15:00:00Z");  // 한국시간 7/25일 00:00
+//        Review reviewToday2 = createReview(4L, 4L, "2025-07-25T14:59:59Z");  // 한국시간 7/25일 23:59
+//
+//        List<Review> totalReviews = List.of(
+//            notInPeriodReview1,
+//            notInPeriodReview2,
+//            reviewYesterday2,
+//            reviewYesterday1,
+//            reviewToday1,
+//            reviewToday2
+//        );
+//        List<PopularReview> expectedPopularReviews = List.of(
+//            createPopularReview(reviewYesterday2, PeriodType.DAILY, 1L, 2.0),
+//            createPopularReview(reviewYesterday1, PeriodType.DAILY, 2L, 1.0)
+//        );
+//
+//        // when
+//        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(totalReviews,
+//            PeriodType.DAILY, contribution, currentTime);
+//
+//        // then
+//        assertThat(result).hasSize(2);
+//        assertThat(result.get(0).getRank()).isEqualTo(1L);
+//        assertThat(result.get(0).getScore()).isEqualTo(2.0);
+//        assertThat(result.get(1).getRank()).isEqualTo(2L);
+//        assertThat(result.get(1).getScore()).isEqualTo(1.0);
+//        then(popularReviewRepository).should().saveAll(any());
+//        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
+//    }
 
 
     @Test

--- a/src/test/java/com/sprint/deokhugam/domain/popularreview/service/PopularReviewServiceTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/popularreview/service/PopularReviewServiceTest.java
@@ -21,6 +21,7 @@ import com.sprint.deokhugam.domain.popularreview.entity.PopularReview;
 import com.sprint.deokhugam.domain.popularreview.mapper.PopularReviewMapper;
 import com.sprint.deokhugam.domain.popularreview.repository.PopularReviewRepository;
 import com.sprint.deokhugam.domain.review.entity.Review;
+import com.sprint.deokhugam.domain.review.repository.ReviewRepository;
 import com.sprint.deokhugam.domain.user.entity.User;
 import com.sprint.deokhugam.global.dto.response.CursorPageResponse;
 import com.sprint.deokhugam.global.enums.PeriodType;
@@ -29,6 +30,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -51,6 +53,9 @@ public class PopularReviewServiceTest {
 
     @Mock
     private PopularReviewRepository popularReviewRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
 
     @Mock
     private PopularReviewMapper popularReviewMapper;
@@ -126,154 +131,54 @@ public class PopularReviewServiceTest {
             .isInstanceOf(BatchAlreadyRunException.class);
     }
 
-//    @Test
-//    void 전체기간_기준으로_인기리뷰를_저장한다() {
-//        //given
-//        Review review1 = createReview(1L, 1L, "2025-01-03T00:00:00Z");
-//        Review review2 = createReview(3L, 3L, "2025-06-03T00:00:00Z");
-//        Review review3 = createReview(2L, 2L, "2025-07-22T00:00:00Z");
-//        List<Review> totalReviews = List.of(
-//            review1,
-//            review2,
-//            review3
-//        );
-//        List<PopularReview> expectedPopularReviews = List.of(
-//            createPopularReview(review1, PeriodType.ALL_TIME, 1L,
-//                review1.getCommentCount() * 0.7 + review1.getLikeCount() * 0.3),
-//            createPopularReview(review2, PeriodType.ALL_TIME, 2L,
-//                review2.getCommentCount() * 0.7 + review2.getLikeCount() * 0.3),
-//            createPopularReview(review3, PeriodType.ALL_TIME, 3L,
-//                review3.getCommentCount() * 0.7 + review3.getLikeCount() * 0.3)
-//        );
-//
-//        // when
-//        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(totalReviews,
-//            PeriodType.ALL_TIME,
-//            contribution, Instant.now());
-//
-//        // then
-//        assertThat(result).hasSize(3);
-//        assertThat(result.get(0).getRank()).isEqualTo(1L);
-//        assertThat(result.get(0).getScore()).isEqualTo(1L * 0.7 + 1L * 0.3);
-//        then(popularReviewRepository).should().saveAll(any());
-//        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
-//    }
-//
-//    @Test
-//    void 월기간_기준으로_인기리뷰를_저장한다() {
-//        //given
-//        Review review1 = createReview(1L, 1L, "2025-07-03T00:00:00Z");
-//        Review notInPeriodReview = createReview(3L, 3L, "2025-06-01T00:00:00Z");
-//        Review review3 = createReview(2L, 2L, "2025-07-22T00:00:00Z");
-//        List<Review> totalReviews = List.of(
-//            review3,
-//            notInPeriodReview,
-//            review1
-//        );
-//        List<PopularReview> expectedPopularReviews = List.of(
-//            createPopularReview(review3, PeriodType.ALL_TIME, 1L,
-//                review3.getCommentCount() * 0.7 + review3.getLikeCount() * 0.3),
-//            createPopularReview(review1, PeriodType.ALL_TIME, 2L,
-//                review1.getCommentCount() * 0.7 + review1.getLikeCount() * 0.3)
-//        );
-//
-//        // when
-//        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(totalReviews,
-//            PeriodType.MONTHLY, contribution, Instant.parse("2025-07-23T00:00:00Z"));
-//
-//        // then
-//        assertThat(result).hasSize(2);
-//        assertThat(result.get(0).getRank()).isEqualTo(1L);
-//        assertThat(result.get(0).getScore()).isEqualTo(
-//            review3.getCommentCount() * 0.7 + review3.getLikeCount() * 0.3);
-//        then(popularReviewRepository).should().saveAll(any());
-//        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
-//    }
-//
-//    @Test
-//    @DisplayName("주간 인기리뷰:7/18~7/24일 데이터를 가져온다(한국시간기준)")
-//    void 주기간_기준으로_인기리뷰를_저장한다() {
-//        //given
-//        Instant currentTime = Instant.parse("2025-07-24T15:05:00Z"); // 한국시간 7/25일 00:05
-//        Review notInPeriodReview1 = createReview(3L, 3L, "2025-06-01T00:00:00Z");
-//        Review notInPeriodReview2 = createReview(2L, 2L,
-//            "2025-07-17T14:49:00Z"); // 한국시간 7/17일 23:59
-//        Review notInPeriodReview3 = createReview(2L, 2L,
-//            "2025-07-25T15:00:00Z"); // 한국시간 7/26일 00:00
-//
-//        Review review1 = createReview(1L, 1L, "2025-07-17T15:00:00Z");  // 한국시간 7/18일 00:00
-//        Review review2 = createReview(2L, 2L, "2025-07-24T14:49:00Z");  // 한국시간 7/24일 23:59
-//        Review reviewToday1 = createReview(3L, 3L, "2025-07-24T15:00:00Z");  // 한국시간 7/25일 00:00
-//        Review reviewToday2 = createReview(4L, 4L, "2025-07-25T14:59:59Z");  // 한국시간 7/25일 23:59
-//
-//        List<Review> totalReviews = List.of(
-//            notInPeriodReview1,
-//            notInPeriodReview2,
-//            notInPeriodReview3,
-//            reviewToday2,
-//            reviewToday1,
-//            review2,
-//            review1
-//        );
-//        List<PopularReview> expectedPopularReviews = List.of(
-//            createPopularReview(review2, PeriodType.WEEKLY, 1L, 2.0),
-//            createPopularReview(review1, PeriodType.WEEKLY, 2L, 1.0)
-//        );
-//
-//        // when
-//        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(totalReviews,
-//            PeriodType.WEEKLY, contribution, currentTime);
-//
-//        // then
-//        assertThat(result).hasSize(2);
-//        assertThat(result.get(1).getRank()).isEqualTo(2L);
-//        assertThat(result.get(1).getScore()).isEqualTo(1.0);
-//        then(popularReviewRepository).should().saveAll(any());
-//        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
-//
-//    }
-//
-//    @Test
-//    @DisplayName("일간 인기리뷰:7/24일 데이터를 가져온다(한국시간기준)")
-//    void 일기간_기준으로_인기리뷰를_저장한다() {
-//
-//        //given
-//        Instant currentTime = Instant.parse("2025-07-24T15:05:00Z"); // 한국시간 7/25일 00:05
-//        Review notInPeriodReview1 = createReview(3L, 3L, "2025-06-01T00:00:00Z");
-//        Review notInPeriodReview2 = createReview(2L, 2L,
-//            "2025-07-23T14:59:00Z"); // 한국시간 7/23일 23:59
-//        Review reviewYesterday1 = createReview(1L, 1L, "2025-07-23T15:00:00Z");  // 한국시간 7/24일 00:00
-//        Review reviewYesterday2 = createReview(2L, 2L, "2025-07-24T14:59:00Z");  // 한국시간 7/24일 23:59
-//        Review reviewToday1 = createReview(3L, 3L, "2025-07-24T15:00:00Z");  // 한국시간 7/25일 00:00
-//        Review reviewToday2 = createReview(4L, 4L, "2025-07-25T14:59:59Z");  // 한국시간 7/25일 23:59
-//
-//        List<Review> totalReviews = List.of(
-//            notInPeriodReview1,
-//            notInPeriodReview2,
-//            reviewYesterday2,
-//            reviewYesterday1,
-//            reviewToday1,
-//            reviewToday2
-//        );
-//        List<PopularReview> expectedPopularReviews = List.of(
-//            createPopularReview(reviewYesterday2, PeriodType.DAILY, 1L, 2.0),
-//            createPopularReview(reviewYesterday1, PeriodType.DAILY, 2L, 1.0)
-//        );
-//
-//        // when
-//        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(totalReviews,
-//            PeriodType.DAILY, contribution, currentTime);
-//
-//        // then
-//        assertThat(result).hasSize(2);
-//        assertThat(result.get(0).getRank()).isEqualTo(1L);
-//        assertThat(result.get(0).getScore()).isEqualTo(2.0);
-//        assertThat(result.get(1).getRank()).isEqualTo(2L);
-//        assertThat(result.get(1).getScore()).isEqualTo(1.0);
-//        then(popularReviewRepository).should().saveAll(any());
-//        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
-//    }
+    @Test
+    void 전체기간_기준으로_인기리뷰를_저장한다() {
+        //given
+        Review review1 = createReview(1L, 1L, "2025-01-03T00:00:00Z");
+        Review review2 = createReview(3L, 3L, "2025-06-03T00:00:00Z");
+        Review review3 = createReview(2L, 2L, "2025-07-22T00:00:00Z");
+        List<Review> totalReviews = List.of(
+            review1,
+            review2,
+            review3
+        );
+        List<PopularReview> expectedPopularReviews = List.of(
+            createPopularReview(review1, PeriodType.ALL_TIME, 1L,
+                review1.getCommentCount() * 0.7 + review1.getLikeCount() * 0.3),
+            createPopularReview(review2, PeriodType.ALL_TIME, 2L,
+                review2.getCommentCount() * 0.7 + review2.getLikeCount() * 0.3),
+            createPopularReview(review3, PeriodType.ALL_TIME, 3L,
+                review3.getCommentCount() * 0.7 + review3.getLikeCount() * 0.3)
+        );
 
+        Map<UUID, Long> commentMap = Map.of(
+            review1.getId(), 1L,
+            review2.getId(), 3L,
+            review3.getId(), 2L
+        );
+        Map<UUID, Long> likeMap = Map.of(
+            review1.getId(), 1L,
+            review2.getId(), 3L,
+            review3.getId(), 2L
+        );
+
+        given(reviewRepository.findAllById(any())).willReturn(totalReviews);
+
+        // when
+        List<PopularReview> result = popularReviewService.savePopularReviewsByPeriod(
+            PeriodType.ALL_TIME,
+            Instant.now(),
+            commentMap,
+            likeMap,
+            contribution);
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getRank()).isEqualTo(1L);
+        assertThat(result.get(0).getScore()).isEqualTo(3L * 0.7 + 3L * 0.3);
+        then(popularReviewRepository).should().saveAll(any());
+        then(contribution).should().incrementWriteCount(expectedPopularReviews.size());
+    }
 
     @Test
     void getPopularReviews_정상작동() {
@@ -492,6 +397,9 @@ public class PopularReviewServiceTest {
         ReflectionTestUtils.setField(review, "likeCount", likeCount);
         ReflectionTestUtils.setField(review, "commentCount", commentCount);
         ReflectionTestUtils.setField(review, "createdAt", Instant.parse(createdAt));
+
+        UUID reviewId = UUID.randomUUID();
+        ReflectionTestUtils.setField(review, "id", reviewId);
 
         return review;
     }

--- a/src/test/java/com/sprint/deokhugam/domain/review/repository/CustomReviewRepositoryTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/review/repository/CustomReviewRepositoryTest.java
@@ -312,15 +312,4 @@ public class CustomReviewRepositoryTest {
         // then
         assertThat(result).isEmpty();
     }
-
-    @Test
-    void 코멘트_또는_좋아요가_있는_리뷰중에_점수를_계산해서_DESC_정렬로_가져온다() {
-        // when
-        List<Review> result = reviewRepository.findAllByCommentCountAndLikeCountWithSorting();
-
-        // then
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).getContent()).isEqualTo("리뷰2"); // 가장 높은 점수 리뷰
-        assertThat(result.get(1).getContent()).isEqualTo("리뷰3"); // 가장 낮은 점수 리뷰
-    }
 }

--- a/src/test/java/com/sprint/deokhugam/domain/reviewlike/repository/ReviewLikeRepositoryTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/reviewlike/repository/ReviewLikeRepositoryTest.java
@@ -1,0 +1,117 @@
+package com.sprint.deokhugam.domain.reviewlike.repository;
+
+import static com.sprint.deokhugam.fixture.BookFixture.createBookEntity;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sprint.deokhugam.domain.book.entity.Book;
+import com.sprint.deokhugam.domain.review.entity.Review;
+import com.sprint.deokhugam.domain.reviewlike.entity.ReviewLike;
+import com.sprint.deokhugam.domain.user.entity.User;
+import com.sprint.deokhugam.global.config.JpaAuditingConfig;
+import com.sprint.deokhugam.global.config.QueryDslConfig;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import({JpaAuditingConfig.class, QueryDslConfig.class})
+@ActiveProfiles("test")
+@DisplayName("ReviewLikeRepository 단위 테스트")
+class ReviewLikeRepositoryTest {
+
+    @Autowired
+    private ReviewLikeRepository reviewLikeRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @BeforeEach
+    void setUp() {
+        // 유저 2명
+        User user1 = em.persist(User.builder()
+            .email("user1@test.com")
+            .nickname("user1")
+            .password("pass")
+            .build());
+
+        User user2 = em.persist(User.builder()
+            .email("user2@test.com")
+            .nickname("user2")
+            .password("pass")
+            .build());
+
+        // 책 1권
+        Book book = em.persist(createBookEntity("테스트 책", "작가", "설명",
+            "출판사", LocalDate.of(2023, 1, 1), "9031245672313",
+            null, 4.0, 3L));
+
+        // 리뷰 2개
+        Review review1 = em.persist(Review.builder()
+            .content("리뷰 1")
+            .likeCount(1L)
+            .commentCount(2L)
+            .rating(5)
+            .book(book)
+            .user(user1)
+            .isDeleted(false)
+            .build());
+
+        Review review2 = em.persist(Review.builder()
+            .content("리뷰 2")
+            .likeCount(1L)
+            .commentCount(2L)
+            .rating(4)
+            .book(book)
+            .user(user2)
+            .isDeleted(false)
+            .build());
+
+        // 좋아요 생성일: 2024-01-10, 2024-02-01
+        Instant inRange = Instant.parse("2024-01-10T00:00:00Z");
+        Instant outOfRange = Instant.parse("2024-02-01T00:00:00Z");
+
+        ReviewLike like1 = new ReviewLike(review1, user2);
+        ReviewLike like2 = new ReviewLike(review2, user1);
+
+        em.persist(like1);
+        em.persist(like2);
+
+        em.flush();
+        em.clear();
+
+        em.getEntityManager().createQuery("UPDATE ReviewLike r SET r.createdAt = :createdAt WHERE r.id = :id")
+            .setParameter("createdAt", inRange)
+            .setParameter("id", like1.getId())
+            .executeUpdate();
+
+        em.getEntityManager().createQuery("UPDATE ReviewLike r SET r.createdAt = :createdAt WHERE r.id = :id")
+            .setParameter("createdAt", outOfRange)
+            .setParameter("id", like2.getId())
+            .executeUpdate();
+    }
+
+    @Test
+    void 특정_기간_동안_추가_된_좋아요_개수_테스트() {
+
+        // given
+        Instant start = Instant.parse("2024-01-01T00:00:00Z");
+        Instant end = Instant.parse("2024-01-31T23:59:00Z");
+
+        // when
+        Map<UUID, Long> result = reviewLikeRepository.countByReviewIdBetween(start, end);
+
+        // then
+        assertEquals(1, result.size());
+        assertTrue(result.values().contains(1L));
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약
- 인기 리뷰 점수 산정 시 특정 기간 동안 추가된 좋아요 수와 댓글 수를 사용하도록 변경

## ✅ 작업 상세 내용
- [x] 인기 리뷰 점수 산정 시 특정 기간 동안 추가된 좋아요 수와 댓글 수를 사용하도록 변경
- [x] 특정 기간 동안 추가된 좋아요, 댓글 수 조회 기능 추가 
- [x] QueryDsl 사용을 위해 `ReviewLikeRepositoryCustom`, `CommentRepositoryCustom` 추가

## 🧪 테스트 방법
<img width="1376" height="626" alt="image" src="https://github.com/user-attachments/assets/b23651a5-2a04-435c-96bb-a6b1f98fbf03" />

## 📎 관련 이슈

## 추가 전달 사항
특정 기간 동안의 좋아요, 댓글 개수 조회 테스트를 `ReviewLikeRepositoryCustom`, `CommentRepositoryCustom`에서 해서 `PopularReviewService`의 커버리지가 제대로 나와서 월간, 주간, 일간 테스트를 지웠는데  참고 부탁드립니다 :)
리뷰 쪽 맡으신 @yeokyeong , @hyohyo-zz 님이 리뷰 해주시면 좋을 것 같습니다~!