### PR TITLE
Fix/INSTANT.MAX 제거 

### DIFF
--- a/src/main/java/com/sprint/deokhugam/domain/popularreview/batch/ReviewBatch.java
+++ b/src/main/java/com/sprint/deokhugam/domain/popularreview/batch/ReviewBatch.java
@@ -67,22 +67,25 @@ public class ReviewBatch {
                     Instant end = period.getEndInstant(currentTime, zoneId);
 
                     // 특정 기간 동안 추가된 댓글 / 좋아요 수
-                    Map<UUID, Long> commentMap = commentRepository.countByReviewIdBetween(start, end);
-                    Map<UUID, Long> likeMap = reviewLikeRepository.countByReviewIdBetween(start, end);
-                    
+                    Map<UUID, Long> commentMap = commentRepository.countByReviewIdBetween(start,
+                        end);
+                    Map<UUID, Long> likeMap = reviewLikeRepository.countByReviewIdBetween(start,
+                        end);
+
                     popularReviewService.savePopularReviewsByPeriod(
                         period, currentTime, commentMap, likeMap, stepContribution
                     );
                 }
+                return RepeatStatus.FINISHED;
             } catch (BatchAlreadyRunException e) {
-                log.error(e.getMessage(), e);
+                log.info(e.getMessage(), e);
                 stepContribution.incrementProcessSkipCount();
+                return RepeatStatus.FINISHED;
             } catch (Exception e) {
                 log.error(e.getMessage(), e);
                 stepContribution.incrementProcessSkipCount();
                 throw e;
             }
-            return RepeatStatus.FINISHED;
         };
     }
 }

--- a/src/main/java/com/sprint/deokhugam/global/batch/BatchScheduler.java
+++ b/src/main/java/com/sprint/deokhugam/global/batch/BatchScheduler.java
@@ -22,7 +22,7 @@ public class BatchScheduler {
     private final Job powerUserJob;
 
 
-    @Scheduled(cron = "35 * * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 5 0 * * *", zone = "Asia/Seoul")
     public void runPopularReviewJob() throws Exception {
         JobParameters params = new JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())
@@ -30,7 +30,7 @@ public class BatchScheduler {
         jobLauncher.run(popularReviewJob, params);
     }
 
-    @Scheduled(cron = "45 * * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 6 0 * * *", zone = "Asia/Seoul")
     public void runPopularBookRankingJob() {
         Instant today = Instant.now();
 
@@ -53,7 +53,7 @@ public class BatchScheduler {
     }
 
     // PowerUser Job 스케줄링 추가
-    @Scheduled(cron = "0 1/1 * * * *", zone = "Asia/Seoul") // 1분마다 실행
+    @Scheduled(cron = "0 7 0 * * *", zone = "Asia/Seoul")
     public void runPowerUserJob() {
         try {
             JobParameters jobParameters = new JobParametersBuilder()

--- a/src/main/java/com/sprint/deokhugam/global/enums/PeriodType.java
+++ b/src/main/java/com/sprint/deokhugam/global/enums/PeriodType.java
@@ -54,7 +54,7 @@ public enum PeriodType {
 
         @Override
         public Instant getEndInstant(Instant today, ZoneId zone) {
-            return Instant.MAX;
+            return Instant.parse("9999-12-31T23:59:59Z");
         }
     };
 

--- a/src/test/java/com/sprint/deokhugam/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/sprint/deokhugam/domain/comment/repository/CommentRepositoryTest.java
@@ -144,7 +144,7 @@ class CommentRepositoryTest {
 
         // given
         Instant start = Instant.MIN;
-        Instant end = Instant.MAX;
+        Instant end = Instant.parse("9999-12-31T23:59:59Z");
         Comment comment = createComment("테스트용", Instant.now());
         em.persist(comment);
         em.flush();
@@ -155,11 +155,11 @@ class CommentRepositoryTest {
 
         // then
         assertEquals(1, result.size());
-        assert(result.values().contains(1L));
+        assert (result.values().contains(1L));
     }
 
     @Test
-    void  ASC_정렬로_댓글을_조회하면_오래된_순으로_반환된다() {
+    void ASC_정렬로_댓글을_조회하면_오래된_순으로_반환된다() {
         // given
         Instant baseTime = Instant.now();
         Comment comment1 = createCommentWithTime("댓1", baseTime.minusSeconds(300));


### PR DESCRIPTION
## 📌 PR 요약
- postgres에서 INSTANT.MAX 타입은 지원하지않는 범위라고합니다. 
  - INSTANT.MAX 타입 대신 지원하는 날짜 최댓값 넣었습니다. 
<img width="613" height="833" alt="스크린샷 2025-07-28 14 15 08" src="https://github.com/user-attachments/assets/7be6e150-4158-45bd-b7d9-adeb0da7b36d" />

- 배치 시간 일 단위로 변경했습니다.
  - 리뷰 00:05, 도서 00:06, 유저 00:07
 
- 인기리뷰에서 이미 배치가 실행됐을때 나오는 에러 로그레벨을 낮췄습니다(error -> info)


## ✅ 작업 상세 내용


## 🧪 테스트 방법
- 기능 테스트 방식 또는 실행 방법을 설명해주세요.

## 📎 관련 이슈
- Close #123

## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 배치 작업의 실행 스케줄이 매일 새벽 특정 시간(00:05, 00:06, 00:07)으로 변경되었습니다.
  * 일부 로그 레벨이 에러에서 정보로 조정되었습니다.
  * 시간 범위 관련 반환값이 `Instant.MAX`에서 `"9999-12-31T23:59:59Z"`로 변경되었습니다.

* **Tests**
  * 테스트 코드 내 시간 범위 검증이 새로운 기준(`"9999-12-31T23:59:59Z"`)으로 수정되었습니다.
  * 코드 포맷이 일부 정돈되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->