### PR TITLE
fix: 댓글목록조회 커서값 createdAt으로 변경

### DIFF
--- a/src/main/java/com/sprint/deokhugam/domain/comment/repository/CustomCommentRepository.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/repository/CustomCommentRepository.java
@@ -12,7 +12,7 @@ public interface CustomCommentRepository {
     List<Comment> fetchComments(
         UUID reviewId,
         Instant cursor,
-        UUID after,
+        Instant after,
         Sort.Direction direction,
         int fetchSize
     );

--- a/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/service/CommentServiceImpl.java
@@ -112,10 +112,10 @@ public class CommentServiceImpl implements CommentService {
         Sort.Direction sortDirection = Sort.Direction.fromString(direction.toUpperCase());
 
         Instant cursorTime = parseInstant(cursor);
-        UUID afterId = parseUUID(after);
+        Instant afterTime = parseInstant(after);
 
         int fetchSize = limit + 1;
-        List<Comment> comments = commentRepository.fetchComments(reviewId, cursorTime, afterId,
+        List<Comment> comments = commentRepository.fetchComments(reviewId, cursorTime, afterTime,
             sortDirection, fetchSize);
 
         boolean hasNext = comments.size() > limit;
@@ -193,17 +193,6 @@ public class CommentServiceImpl implements CommentService {
             return Instant.parse(value);
         } catch (DateTimeParseException e) {
             throw new InvalidCursorTypeException(value, e.getMessage());
-        }
-    }
-
-    private UUID parseUUID(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        try {
-            return UUID.fromString(value);
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("올바르지 않은 after(UUID) 형식입니다: " + value);
         }
     }
 }


### PR DESCRIPTION
## 📌 PR 요약
- 흑흑쓴 커서값(after) createdAt으로 수정했습니당

## ✅ 작업 상세 내용
- [ ] 주요 기능 구현
- [ ] 관련 API 변경
- [ ] 기타 리팩터링

## 🧪 테스트 방법
- 기능 테스트 방식 또는 실행 방법을 설명해주세요.
<img width="869" height="739" alt="스크린샷 2025-07-29 005701" src="https://github.com/user-attachments/assets/37525a47-7d10-4f33-82ba-44114d781902" />


## 📎 관련 이슈
- Close #123

## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * 댓글 조회 시 페이지네이션 기준 파라미터가 UUID에서 시간(Instant) 기반으로 변경되었습니다.  
  * 일부 내부 처리 로직이 시간 기준으로 정리되어, 댓글 목록의 정렬 및 조회 방식이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->