### PR TITLE
fix: 누락된 인증헤더 추가

### DIFF
--- a/src/main/java/com/sprint/deokhugam/domain/book/controller/api/BookApi.java
+++ b/src/main/java/com/sprint/deokhugam/domain/book/controller/api/BookApi.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.io.IOException;
@@ -37,7 +38,11 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "도서 관리", description = "도서 관련 API")
 public interface BookApi {
 
-    @Operation(summary = "도서 등록", description = "새로운 도서를 등록합니다.")
+    @Operation(
+        summary = "도서 등록"
+        , description = "새로운 도서를 등록합니다."
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
     @ApiResponses({
         @ApiResponse(
             responseCode = "201",
@@ -82,7 +87,11 @@ public interface BookApi {
         @RequestPart(value = "thumbnailImage", required = false) MultipartFile thumbnailImage)
         throws IOException;
 
-    @Operation(summary = "도서 목록 조회", description = "검색 조건에 맞는 도서 목록을 조회합니다.")
+    @Operation(
+        summary = "도서 목록 조회"
+        , description = "검색 조건에 맞는 도서 목록을 조회합니다."
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
     @ApiResponses({
         @ApiResponse(
             responseCode = "200",
@@ -132,7 +141,10 @@ public interface BookApi {
         @RequestParam(defaultValue = "50") Integer limit
     );
 
-    @Operation(summary = "도서 정보 상세 조회", description = "도서 상세 정보 조회")
+    @Operation(
+        summary = "도서 정보 상세 조회"
+        , description = "도서 상세 정보 조회"
+        , security = @SecurityRequirement(name = "CustomHeaderAuth"))
     @ApiResponses({
         @ApiResponse(
             responseCode = "200",
@@ -164,8 +176,11 @@ public interface BookApi {
         @Parameter(description = "도서 ID", example = "9a4d6e2b-8f53-4c8c-a7c7-21d5079b8b37")
         @PathVariable UUID bookId);
 
-    @Operation(summary = "ISBN으로 도서 정보 조회",
-        description = "Naver API를 통해 ISBN으로 도서 정보를 조회합니다.")
+    @Operation(
+        summary = "ISBN으로 도서 정보 조회",
+        description = "Naver API를 통해 ISBN으로 도서 정보를 조회합니다."
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
     @ApiResponses({
         @ApiResponse(
             responseCode = "200",
@@ -205,7 +220,11 @@ public interface BookApi {
         @Parameter(description = "ISBN 번호", example = "9788968481901")
         @RequestParam String isbn);
 
-    @Operation(summary = "도서 정보 수정", description = "도서 정보를 수정합니다.")
+    @Operation(
+        summary = "도서 정보 수정"
+        , description = "도서 정보를 수정합니다."
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
     @ApiResponses({
         @ApiResponse(
             responseCode = "200",
@@ -260,8 +279,11 @@ public interface BookApi {
         @RequestPart(value = "thumbnailImage", required = false) MultipartFile thumbnailImage
     ) throws IOException;
 
-    @Operation(summary = "이미지 기반 ISBN 인식",
-        description = "도서 이미지를 통해 ISBN을 인식합니다.")
+    @Operation(
+        summary = "이미지 기반 ISBN 인식",
+        description = "도서 이미지를 통해 ISBN을 인식합니다."
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
     @ApiResponses({
         @ApiResponse(
             responseCode = "200",
@@ -302,8 +324,11 @@ public interface BookApi {
         @RequestPart(value = "image") MultipartFile image
     ) throws OcrException;
 
-    @Operation(summary = "도서 논리 삭제",
-        description = "도서를 논리적으로 삭제합니다.")
+    @Operation(
+        summary = "도서 논리 삭제",
+        description = "도서를 논리적으로 삭제합니다."
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
     @ApiResponses({
         @ApiResponse(
             responseCode = "204",
@@ -324,8 +349,11 @@ public interface BookApi {
             example = "9a4d6e2b-8f53-4c8c-a7c7-21d5079b8b37")
         @PathVariable UUID bookId);
 
-    @Operation(summary = "도서 물리 삭제",
-        description = "도서를 물리적으로 삭제합니다.")
+    @Operation(
+        summary = "도서 물리 삭제",
+        description = "도서를 물리적으로 삭제합니다."
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
+    )
     @ApiResponses({
         @ApiResponse(
             responseCode = "204",

--- a/src/main/java/com/sprint/deokhugam/domain/comment/controller/api/CommentApi.java
+++ b/src/main/java/com/sprint/deokhugam/domain/comment/controller/api/CommentApi.java
@@ -115,6 +115,7 @@ public interface CommentApi {
         summary = "댓글 상세 정보 조회",
         description = "특정 댓글의 상세 정보를 조회합니다.",
         operationId = "getComment"
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
     )
     @ApiResponses(value = {
         @ApiResponse(

--- a/src/main/java/com/sprint/deokhugam/domain/notification/controller/api/NotificationApi.java
+++ b/src/main/java/com/sprint/deokhugam/domain/notification/controller/api/NotificationApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -28,6 +29,7 @@ public interface NotificationApi {
         summary = "알림 읽음 상태 업데이트",
         description = "특정 알림의 읽음 상태를 업데이트합니다.",
         operationId = "updateNotification"
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
     )
     @ApiResponses(value = {
         @ApiResponse(
@@ -70,6 +72,7 @@ public interface NotificationApi {
         summary = "모든 알림 읽음 처리",
         description = "사용자의 모든 알림을 읽음 상태로 처리합니다.",
         operationId = "markAllAsRead"
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
     )
     @ApiResponses(value = {
         @ApiResponse(responseCode = "204", description = "알림 읽음 처리 성공",
@@ -91,6 +94,7 @@ public interface NotificationApi {
         summary = "알림 목록 조회",
         description = "사용자의 알림 목록을 조회합니다.",
         operationId = "getNotifications"
+        , security = @SecurityRequirement(name = "CustomHeaderAuth")
     )
     @ApiResponses(value = {
         @ApiResponse(

--- a/src/main/java/com/sprint/deokhugam/domain/user/controller/api/UserApi.java
+++ b/src/main/java/com/sprint/deokhugam/domain/user/controller/api/UserApi.java
@@ -251,18 +251,6 @@ public interface UserApi {
 
         @Parameter(description = "페이지 크기")
         @RequestParam(defaultValue = "50") @Min(1) @Max(100) int limit
-
-//        혹은,
-//        @Parameter(
-//            description = """
-//                파워 유저 목록 조회용 DTO<br>
-//                - **period**: 랭킹 기간 (DAILY, WEEKLY, MONTHLY, ALL_TIME, 기본값: DAILY)<br>
-//                - **direction**: 정렬 방향 (ASC, DESC, 기본값: ASC)<br>
-//                - **cursor**: 커서 페이지네이션을 커서<br>
-//                - **after**: createdAt 기준 보조 커서<br>
-//                - **limit**: 페이지 크기 (기본값: 50)
-//                """
-//        )@ModelAttribute @Valid PowerUserGetRequest request;
     );
 
 }


### PR DESCRIPTION
## 📌 PR 요약
- api 호출시 헤더 정보를 명시하는 @security 누락된 부분이 있어 추가했습니당
- 로그인, 회원가입, 대시보드 기능은 제외합니다

## ✅ 작업 상세 내용
- [ ] 주요 기능 구현
- [ ] 관련 API 변경
- [ ] 기타 리팩터링

## 🧪 테스트 방법
- 기능 테스트 방식 또는 실행 방법을 설명해주세요.
- <img width="570" height="456" alt="스크린샷 2025-07-29 101923" src="https://github.com/user-attachments/assets/263b807f-e4ad-4297-8a23-281d4bb1e62f" />

## 📎 관련 이슈
- Close #123

## 추가 전달 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * Book, Comment, Notification API 엔드포인트에 "CustomHeaderAuth" 보안 요구 사항이 명시되어, OpenAPI 문서에서 인증 필요 여부가 명확하게 표시됩니다.
  * User API 내 불필요한 주석 코드가 제거되어 문서가 간결해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->